### PR TITLE
DiskBasedCache rewrite with unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <java.version>1.6</java.version>
+    <java.version>1.7</java.version>
   </properties>
 
   <dependencies>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -37,7 +37,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
        <artifactId>mockito-core</artifactId>
-       <version>1.9.5</version>
+       <version>2.2.16</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/rules.gradle
+++ b/rules.gradle
@@ -5,8 +5,9 @@ apply plugin: 'com.android.library'
 // Check if the android plugin version supports unit testing.
 if (configurations.findByName("testCompile")) {
   dependencies {
-    testCompile "junit:junit:4.10"
-    testCompile "org.mockito:mockito-core:1.9.5"
+    testCompile "junit:junit:4.12"
+    testCompile "org.hamcrest:hamcrest-library:1.3"
+    testCompile "org.mockito:mockito-core:2.2.16"
     testCompile "org.robolectric:robolectric:3.0"
   }
 }

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -18,119 +18,404 @@ package com.android.volley.toolbox;
 
 import com.android.volley.Cache;
 import com.android.volley.toolbox.DiskBasedCache.CacheHeader;
+import com.android.volley.toolbox.DiskBasedCache.CountingInputStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.Random;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
+@RunWith(RobolectricTestRunner.class)
 public class DiskBasedCacheTest {
 
-    // Simple end-to-end serialize/deserialize test.
-    @Test public void cacheHeaderSerialization() throws Exception {
-        Cache.Entry e = new Cache.Entry();
-        e.data = new byte[8];
-        e.serverDate = 1234567L;
-        e.lastModified = 13572468L;
-        e.ttl = 9876543L;
-        e.softTtl = 8765432L;
-        e.etag = "etag";
-        e.responseHeaders = new HashMap<String, String>();
-        e.responseHeaders.put("fruit", "banana");
+    private static final String CACHE_FOLDER = "test";
+    private static final int MAX_SIZE = 1024 * 1024;
 
-        CacheHeader first = new CacheHeader("my-magical-key", e);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        first.writeHeader(baos);
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        CacheHeader second = CacheHeader.readHeader(bais);
+    private Cache cache;
 
-        assertEquals(first.key, second.key);
-        assertEquals(first.serverDate, second.serverDate);
-        assertEquals(first.lastModified, second.lastModified);
-        assertEquals(first.ttl, second.ttl);
-        assertEquals(first.softTtl, second.softTtl);
-        assertEquals(first.etag, second.etag);
-        assertEquals(first.responseHeaders, second.responseHeaders);
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setup() throws IOException {
+        // Initialize empty cache
+        File rootDirectory = new File(temporaryFolder.getRoot(), CACHE_FOLDER);
+        cache = new DiskBasedCache(rootDirectory, MAX_SIZE);
+        cache.initialize();
     }
 
-    @Test public void serializeInt() throws Exception {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DiskBasedCache.writeInt(baos, 0);
-        DiskBasedCache.writeInt(baos, 19791214);
-        DiskBasedCache.writeInt(baos, -20050711);
-        DiskBasedCache.writeInt(baos, Integer.MIN_VALUE);
-        DiskBasedCache.writeInt(baos, Integer.MAX_VALUE);
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        assertEquals(DiskBasedCache.readInt(bais), 0);
-        assertEquals(DiskBasedCache.readInt(bais), 19791214);
-        assertEquals(DiskBasedCache.readInt(bais), -20050711);
-        assertEquals(DiskBasedCache.readInt(bais), Integer.MIN_VALUE);
-        assertEquals(DiskBasedCache.readInt(bais), Integer.MAX_VALUE);
+    @After
+    public void teardown() {
+        cache = null;
     }
 
-    @Test public void serializeLong() throws Exception {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DiskBasedCache.writeLong(baos, 0);
-        DiskBasedCache.writeLong(baos, 31337);
-        DiskBasedCache.writeLong(baos, -4160);
-        DiskBasedCache.writeLong(baos, 4295032832L);
-        DiskBasedCache.writeLong(baos, -4314824046L);
-        DiskBasedCache.writeLong(baos, Long.MIN_VALUE);
-        DiskBasedCache.writeLong(baos, Long.MAX_VALUE);
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        assertEquals(DiskBasedCache.readLong(bais), 0);
-        assertEquals(DiskBasedCache.readLong(bais), 31337);
-        assertEquals(DiskBasedCache.readLong(bais), -4160);
-        assertEquals(DiskBasedCache.readLong(bais), 4295032832L);
-        assertEquals(DiskBasedCache.readLong(bais), -4314824046L);
-        assertEquals(DiskBasedCache.readLong(bais), Long.MIN_VALUE);
-        assertEquals(DiskBasedCache.readLong(bais), Long.MAX_VALUE);
+    @Test
+    public void testEmptyInitialize() {
+        assertThat(cache.get("key"), is(nullValue()));
     }
 
-    @Test public void serializeString() throws Exception {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DiskBasedCache.writeString(baos, "");
-        DiskBasedCache.writeString(baos, "This is a string.");
-        DiskBasedCache.writeString(baos, "ファイカス");
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        assertEquals(DiskBasedCache.readString(bais), "");
-        assertEquals(DiskBasedCache.readString(bais), "This is a string.");
-        assertEquals(DiskBasedCache.readString(bais), "ファイカス");
+    @Test
+    public void testPutGetZeroBytes() {
+        // Random entry from Volley's DiskBasedCacheTest
+        Cache.Entry entry = new Cache.Entry();
+        entry.data = new byte[0];
+        entry.serverDate = 1234567L;
+        entry.lastModified = 13572468L;
+        entry.ttl = 9876543L;
+        entry.softTtl = 8765432L;
+        entry.etag = "etag";
+        entry.responseHeaders = new HashMap<>();
+        entry.responseHeaders.put("fruit", "banana");
+        entry.responseHeaders.put("color", "yellow");
+        cache.put("my-magical-key", entry);
+
+        assertThatEntriesAreEqual(cache.get("my-magical-key"), entry);
+        assertThat(cache.get("unknown-key"), is(nullValue()));
     }
 
-    @Test public void serializeMap() throws Exception {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Map<String, String> empty = new HashMap<String, String>();
-        DiskBasedCache.writeStringStringMap(empty, baos);
-        DiskBasedCache.writeStringStringMap(null, baos);
-        Map<String, String> twoThings = new HashMap<String, String>();
-        twoThings.put("first", "thing");
-        twoThings.put("second", "item");
-        DiskBasedCache.writeStringStringMap(twoThings, baos);
-        Map<String, String> emptyKey = new HashMap<String, String>();
-        emptyKey.put("", "value");
-        DiskBasedCache.writeStringStringMap(emptyKey, baos);
-        Map<String, String> emptyValue = new HashMap<String, String>();
-        emptyValue.put("key", "");
-        DiskBasedCache.writeStringStringMap(emptyValue, baos);
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        assertEquals(DiskBasedCache.readStringStringMap(bais), empty);
-        assertEquals(DiskBasedCache.readStringStringMap(bais), empty); // null reads back empty
-        assertEquals(DiskBasedCache.readStringStringMap(bais), twoThings);
-        assertEquals(DiskBasedCache.readStringStringMap(bais), emptyKey);
-        assertEquals(DiskBasedCache.readStringStringMap(bais), emptyValue);
+    @Test
+    public void testPutRemoveGet() {
+        Cache.Entry entry = randomData(511);
+        cache.put("key", entry);
+
+        assertThatEntriesAreEqual(cache.get("key"), entry);
+
+        cache.remove("key");
+        assertThat(cache.get("key"), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray()));
+    }
+
+    @Test
+    public void testPutClearGet() {
+        Cache.Entry entry = randomData(511);
+        cache.put("key", entry);
+
+        assertThatEntriesAreEqual(cache.get("key"), entry);
+
+        cache.clear();
+        assertThat(cache.get("key"), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray()));
+    }
+
+    @Test
+    public void testReinitialize() {
+        Cache.Entry entry = randomData(1023);
+        cache.put("key", entry);
+
+        Cache copy = new DiskBasedCache(new File(temporaryFolder.getRoot(), CACHE_FOLDER));
+        copy.initialize();
+
+        assertThatEntriesAreEqual(copy.get("key"), entry);
+    }
+
+    @Test
+    public void testInvalidate() {
+        Cache.Entry entry = randomData(32);
+        entry.softTtl = 8765432L;
+        entry.ttl = 9876543L;
+        cache.put("key", entry);
+
+        cache.invalidate("key", false);
+        entry.softTtl = 0; // expired
+        assertThatEntriesAreEqual(cache.get("key"), entry);
+    }
+
+    @Test
+    public void testInvalidateFullExpire() {
+        Cache.Entry entry = randomData(32);
+        entry.softTtl = 8765432L;
+        entry.ttl = 9876543L;
+        cache.put("key", entry);
+
+        cache.invalidate("key", true);
+        entry.softTtl = 0; // expired
+        entry.ttl = 0; // expired
+        assertThatEntriesAreEqual(cache.get("key"), entry);
+    }
+
+    @Test
+    public void testTrim() {
+        Cache.Entry entry = randomData(2 * MAX_SIZE);
+        cache.put("oversize", entry);
+
+        assertThatEntriesAreEqual(cache.get("oversize"), entry);
+
+        entry = randomData(1024);
+        cache.put("kilobyte", entry);
+
+        assertThat(cache.get("oversize"), is(nullValue()));
+        assertThatEntriesAreEqual(cache.get("kilobyte"), entry);
+
+        Cache.Entry entry2 = randomData(1024);
+        cache.put("kilobyte2", entry2);
+        Cache.Entry entry3 = randomData(1024);
+        cache.put("kilobyte3", entry3);
+
+        assertThatEntriesAreEqual(cache.get("kilobyte"), entry);
+        assertThatEntriesAreEqual(cache.get("kilobyte2"), entry2);
+        assertThatEntriesAreEqual(cache.get("kilobyte3"), entry3);
+
+        entry = randomData(MAX_SIZE);
+        cache.put("max", entry);
+
+        assertThat(cache.get("kilobyte"), is(nullValue()));
+        assertThat(cache.get("kilobyte2"), is(nullValue()));
+        assertThat(cache.get("kilobyte3"), is(nullValue()));
+        assertThatEntriesAreEqual(cache.get("max"), entry);
+    }
+
+    @Test
+    @SuppressWarnings("TryFinallyCanBeTryWithResources")
+    public void testGetBadMagic() throws IOException {
+        // Cache something
+        Cache.Entry entry = randomData(1023);
+        cache.put("key", entry);
+        assertThatEntriesAreEqual(cache.get("key"), entry);
+
+        // Overwrite the magic header
+        File cacheFolder = new File(temporaryFolder.getRoot(), CACHE_FOLDER);
+        File file = cacheFolder.listFiles()[0];
+        RandomAccessFile rwFile = new RandomAccessFile(file, "rw");
+        try {
+            rwFile.writeInt(0); // overwrite magic
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            rwFile.close();
+        }
+
+        assertThat(cache.get("key"), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray()));
+    }
+
+    @Test
+    @SuppressWarnings("TryFinallyCanBeTryWithResources")
+    public void testGetWrongKey() throws IOException {
+        // Cache something
+        Cache.Entry entry = randomData(1023);
+        cache.put("key", entry);
+        assertThatEntriesAreEqual(cache.get("key"), entry);
+
+        // Access the cached file
+        File cacheFolder = new File(temporaryFolder.getRoot(), CACHE_FOLDER);
+        File file = cacheFolder.listFiles()[0];
+        RandomAccessFile rwFile = new RandomAccessFile(file, "rw");
+
+        // Overwrite with a different key
+        CacheHeader wrongHeader = new CacheHeader("bad", entry);
+        try {
+            wrongHeader.writeFields(rwFile);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            rwFile.close();
+        }
+
+        // key is gone, but file is still there
+        assertThat(cache.get("key"), is(nullValue()));
+        assertThat(listCachedFiles(), is(arrayWithSize(1)));
+
+        // Note: file is now a zombie because its key does not map to its name
+    }
+
+    @Test
+    @SuppressWarnings("TryFinallyCanBeTryWithResources")
+    public void testGetWrongLength() {
+        // Cache something
+        Cache.Entry entry = randomData(1023);
+        cache.put("key", entry);
+        assertThatEntriesAreEqual(cache.get("key"), entry);
+
+        // Sneakily overwrite with a different length
+        Cache copy = new DiskBasedCache(new File(temporaryFolder.getRoot(), CACHE_FOLDER));
+        copy.initialize();
+        copy.put("key", randomData(127));
+
+        // Item is removed when we try to get it
+        assertThat(cache.get("key"), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray()));
+    }
+
+    @Test
+    public void testFileIsDeletedWhenWriteHeaderFails() throws IOException {
+        // Create DataOutputStream that throws IOException
+        OutputStream mockedOutputStream = spy(OutputStream.class);
+        doThrow(IOException.class).when(mockedOutputStream).write(anyInt());
+
+        // Create read-only copy that fails to write anything
+        DiskBasedCache readonly = spy((DiskBasedCache) cache);
+        doReturn(mockedOutputStream).when(readonly).createOutputStream(any(File.class));
+
+        // Attempt to write
+        readonly.put("key", randomData(1111));
+
+        // write is called at least once because each linked stream flushes when closed
+        verify(mockedOutputStream, atLeastOnce()).write(anyInt());
+        assertThat(readonly.get("key"), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray()));
+
+        // Note: original cache will try (without success) to read from file
+        assertThat(cache.get("key"), is(nullValue()));
+    }
+
+    @Test
+    public void testFailuresInInitialize() throws IOException {
+        // Cache a few kilobytes
+        cache.put("kilobyte", randomData(1024));
+        cache.put("kilobyte2", randomData(1024));
+        cache.put("kilobyte3", randomData(1024));
+
+        // Create DataInputStream that throws IOException
+        InputStream mockedInputStream = spy(InputStream.class);
+        //noinspection ResultOfMethodCallIgnored
+        doThrow(IOException.class).when(mockedInputStream).read();
+
+        // Create broken cache that fails to read anything
+        DiskBasedCache broken =
+                spy(new DiskBasedCache(new File(temporaryFolder.getRoot(), CACHE_FOLDER)));
+        doReturn(mockedInputStream).when(broken).createInputStream(any(File.class));
+
+        // Attempt to initialize
+        broken.initialize();
+
+        // Everything is gone
+        assertThat(broken.get("kilobyte"), is(nullValue()));
+        assertThat(broken.get("kilobyte2"), is(nullValue()));
+        assertThat(broken.get("kilobyte3"), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray()));
+
+        // Verify that original cache can cope with missing files
+        assertThat(cache.get("kilobyte"), is(nullValue()));
+        assertThat(cache.get("kilobyte2"), is(nullValue()));
+        assertThat(cache.get("kilobyte3"), is(nullValue()));
+    }
+
+    /* DiskBasedCache.CacheHeader tests */
+
+    @Test
+    public void testAlmostTooManyResponseHeaders() {
+        Cache.Entry entry = new Cache.Entry();
+        entry.data = new byte[0];
+        entry.responseHeaders = new HashMap<>();
+        for (int i = 0; i < 0xFFFF; i++) {
+            entry.responseHeaders.put(Integer.toString(i), "");
+        }
+        cache.put("key", entry);
+    }
+
+    @Test
+    public void testTooManyResponseHeaders() {
+        Cache.Entry entry = new Cache.Entry();
+        entry.data = new byte[0];
+        entry.responseHeaders = new HashMap<>();
+        for (int i = 0; i < 0x10000; i++) {
+            entry.responseHeaders.put(Integer.toString(i), "");
+        }
+        exception.expect(IllegalArgumentException.class);
+        cache.put("key", entry);
+    }
+
+    /* DiskBasedCache.CountingInputStream tests */
+
+    @Test
+    @SuppressWarnings("TryFinallyCanBeTryWithResources")
+    public void testCountingInputStreamByteCount() throws IOException {
+        // Write some bytes
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(out);
+        //noinspection ThrowFromFinallyBlock
+        try {
+            dos.writeInt(1);
+            dos.writeBoolean(true);
+            dos.writeShort(12321);
+            dos.writeLong(-1);
+            dos.writeUTF("hamburger");
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            dos.close();
+        }
+        int bytesWritten = dos.size();
+
+        // Read the bytes and compare the counts
+        CountingInputStream countingInputStream =
+                new CountingInputStream(new ByteArrayInputStream(out.toByteArray()));
+        DataInputStream dis = new DataInputStream(countingInputStream);
+        try {
+            assertThat(countingInputStream.byteCount(), is(0));
+            assertThat(dis.readInt(), is(1));
+            assertThat(dis.readBoolean(), is(true));
+            assertThat(dis.readUnsignedShort(), is(12321));
+            assertThat(dis.readLong(), is(-1L));
+            assertThat(dis.readUTF(), is("hamburger"));
+            assertThat(countingInputStream.byteCount(), is(bytesWritten));
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            dis.close();
+        }
     }
 
     @Test
     public void publicMethods() throws Exception {
         // Catch-all test to find API-breaking changes.
-        assertNotNull(DiskBasedCache.class.getConstructor(File.class, int.class));
-        assertNotNull(DiskBasedCache.class.getConstructor(File.class));
+        assertThat(DiskBasedCache.class.getConstructor(File.class, int.class), is(notNullValue()));
+        assertThat(DiskBasedCache.class.getConstructor(File.class), is(notNullValue()));
+        assertThat(
+                DiskBasedCache.class.getMethod("getFileForKey", String.class), is(notNullValue()));
+    }
 
-        assertNotNull(DiskBasedCache.class.getMethod("getFileForKey", String.class));
+    /* Test helpers */
+
+    private void assertThatEntriesAreEqual(Cache.Entry actual, Cache.Entry expected) {
+        assertThat(actual.data, is(equalTo(expected.data)));
+        assertThat(actual.etag, is(equalTo(expected.etag)));
+        assertThat(actual.lastModified, is(equalTo(expected.lastModified)));
+        assertThat(actual.responseHeaders, is(equalTo(expected.responseHeaders)));
+        assertThat(actual.serverDate, is(equalTo(expected.serverDate)));
+        assertThat(actual.softTtl, is(equalTo(expected.softTtl)));
+        assertThat(actual.ttl, is(equalTo(expected.ttl)));
+    }
+
+    private Cache.Entry randomData(int length) {
+        Cache.Entry entry = new Cache.Entry();
+        byte[] data = new byte[length];
+        new Random().nextBytes(data);
+        entry.data = data;
+        return entry;
+    }
+
+    private File[] listCachedFiles() {
+        return new File(temporaryFolder.getRoot(), CACHE_FOLDER).listFiles();
     }
 }


### PR DESCRIPTION
Rewrite of DiskBasedCache to fix Issue #12 

Changes:

1. DiskBasedCache rewritten using DataInputStream and DataOutputStream for serialization, and incorporating a dataLength field in the cached header in order to detect file corruption before encountering the troublesome OutOfMemoryError.

2. DiskBasedCacheTest unit tests rewritten.
    All tests passing: https://circleci.com/gh/joebowbeer/volley/11
