### PR TITLE
Do not retry on 401 failures.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -157,8 +157,10 @@ public class BasicNetwork implements Network {
                             responseHeaders, false, SystemClock.elapsedRealtime() - requestStart);
                     if (statusCode == HttpStatus.SC_UNAUTHORIZED ||
                             statusCode == HttpStatus.SC_FORBIDDEN) {
-                        attemptRetryOnException("auth",
-                                request, new AuthFailureError(networkResponse));
+                        // Don't retry on Authentication erros per w3 guidance
+                        // see https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+                        // "Authorization will not help and the request SHOULD NOT be repeated"
+                        throw new AuthFailureError(networkResponse);
                     } else if (statusCode >= 400 && statusCode <= 499) {
                         // Don't retry other client errors.
                         throw new ClientError(networkResponse);

--- a/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
@@ -131,8 +131,8 @@ public class BasicNetworkTest {
         } catch (VolleyError e) {
             // expected
         }
-        // should retry in case it's an auth failure.
-        verify(mMockRetryPolicy).retry(any(AuthFailureError.class));
+        // should not retry in case it's an auth failure.
+        verify(mMockRetryPolicy, never()).retry(any(AuthFailureError.class));
     }
 
     @Test public void forbidden() throws Exception {
@@ -149,8 +149,8 @@ public class BasicNetworkTest {
         } catch (VolleyError e) {
             // expected
         }
-        // should retry in case it's an auth failure.
-        verify(mMockRetryPolicy).retry(any(AuthFailureError.class));
+        // should not retry in case it's an auth failure.
+        verify(mMockRetryPolicy, never()).retry(any(AuthFailureError.class));
     }
 
     @Test public void redirect() throws Exception {


### PR DESCRIPTION
auth failures should not be retried, benefit include:

perf improvement
API with limited retries will be set off sooner without this fix
it's the guidance from W3