### PR TITLE
implementing a simple binary search that suits the need of returnBuf() method.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/ByteArrayPool.java
+++ b/src/main/java/com/android/volley/toolbox/ByteArrayPool.java
@@ -121,7 +121,6 @@ public class ByteArrayPool {
         }
 
         int low = 0, high = bufList.size() - 1;
-
         while (low + 1 < high) {
             int mid = (low + high) >>> 1;
             if (buf.length == bufList.get(mid).length) {
@@ -132,7 +131,6 @@ public class ByteArrayPool {
                 low = mid;
             }
         }
-
         return high;
     }
 


### PR DESCRIPTION
the original implementation of returnBuf() method has assumptions on how the Collections.binarySearch() in the sdk is implemented, which may not always be true.
for example, the code in ByteArrayPool 

```

int pos = Collections.binarySearch(mBuffersBySize, buf, BUF_COMPARATOR);
        if (pos < 0) {
            pos = -pos - 1;
        }
```


is dependent on the implementation of binarySearch method in Collections
```
private static <T> int indexedBinarySearch(List<? extends T> l, T key, Comparator<? super T> c) {
        int low = 0;
        int high = l.size()-1;

        while (low <= high) {
            int mid = (low + high) >>> 1;
            T midVal = l.get(mid);
            int cmp = c.compare(midVal, key);

            if (cmp < 0)
                low = mid + 1;
            else if (cmp > 0)
                high = mid - 1;
            else
                return mid; // key found
        }
        return -(low + 1);  // key not found
    }
```

The negative value that's returned by the 'key not found' case is not part of the contract of the binarySearch method, so we might just implement our own binary search method.
This commit writes a binary search method that guarantees the inserting position is correct.


