### PR TITLE
NetworkImageView bug when used with RecyclerView

### DIFF
--- a/src/main/java/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkImageView.java
@@ -204,7 +204,7 @@ public class NetworkImageView extends ImageView {
             // If the view was bound to an image request, cancel it and clear
             // out the image from the view.
             mImageContainer.cancelRequest();
-            setImageBitmap(null);
+
             // also clear out the container so we can reload the image if necessary.
             mImageContainer = null;
         }


### PR DESCRIPTION
I came across a bug where images would sometimes not show while scrolling a NetworkImageView inside a RecyclerView.  I tracked the bug down to this line with the bitmap getting nulled out in `onDetachedFromWindow`. The problem is that `setImageBitmap(null);` depends on `onLayout` getting triggered after `onAttachedToWindow`, but sometimes while scrolling the RecyclerView ends up calling onAttached -> onDetached -> onAttached but onLayout doesn't get retriggered so the bitmap doesn't get set. Setting the bitmap to null is a memory optimization that is better left up to RecyclerView. In non-RecyclerView situations this optimization might be useful but you can't guarantee that onAttached will always trigger an onLayout pass.