### PR TITLE
Cleaned up some duplication

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -137,9 +137,9 @@ public class HurlStack implements HttpStack {
      */
     private static boolean hasResponseBody(int requestMethod, int responseCode) {
         return requestMethod != Request.Method.HEAD
-                && !(HttpStatus.SC_CONTINUE <= responseCode && responseCode < HttpStatus.SC_OK)
-                && responseCode != HttpStatus.SC_NO_CONTENT
-                && responseCode != HttpStatus.SC_NOT_MODIFIED;
+            && !(HttpStatus.SC_CONTINUE <= responseCode && responseCode < HttpStatus.SC_OK)
+            && responseCode != HttpStatus.SC_NO_CONTENT
+            && responseCode != HttpStatus.SC_NOT_MODIFIED;
     }
 
     /**
@@ -201,7 +201,7 @@ public class HurlStack implements HttpStack {
 
     @SuppressWarnings("deprecation")
     /* package */ static void setConnectionParametersForRequest(HttpURLConnection connection,
-                                                                Request<?> request) throws IOException, AuthFailureError {
+            Request<?> request) throws IOException, AuthFailureError {
         switch (request.getMethod()) {
             case Method.DEPRECATED_GET_OR_POST:
                 // This is the deprecated way that needs to be handled for backwards compatibility.
@@ -257,13 +257,13 @@ public class HurlStack implements HttpStack {
 
     private static void addBody(HttpURLConnection connection, Request<?> request, byte[] body)
             throws IOException, AuthFailureError {
-            // Prepare output. There is no need to set Content-Length explicitly,
-            // since this is handled by HttpURLConnection using the size of the prepared
-            // output stream.
-            connection.setDoOutput(true);
-            connection.addRequestProperty(HEADER_CONTENT_TYPE, request.getBodyContentType());
-            DataOutputStream out = new DataOutputStream(connection.getOutputStream());
-            out.write(body);
-            out.close();
+        // Prepare output. There is no need to set Content-Length explicitly,
+        // since this is handled by HttpURLConnection using the size of the prepared
+        // output stream.
+        connection.setDoOutput(true);
+        connection.addRequestProperty(HEADER_CONTENT_TYPE, request.getBodyContentType());
+        DataOutputStream out = new DataOutputStream(connection.getOutputStream());
+        out.write(body);
+        out.close();
     }
 }

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -209,7 +209,6 @@ public class HurlStack implements HttpStack {
                 // GET.  Otherwise, it is assumed that the request is a POST.
                 byte[] postBody = request.getPostBody();
                 if (postBody != null) {
-                    connection.setDoOutput(true);
                     connection.setRequestMethod("POST");
                     addBody(connection, request, postBody);
                 }

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -77,7 +77,7 @@ public class HurlStack implements HttpStack {
     }
 
     /**
-     * @param urlRewriter      Rewriter to use for request URLs
+     * @param urlRewriter Rewriter to use for request URLs
      * @param sslSocketFactory SSL factory to use for HTTPS connections
      */
     public HurlStack(UrlRewriter urlRewriter, SSLSocketFactory sslSocketFactory) {
@@ -130,11 +130,10 @@ public class HurlStack implements HttpStack {
 
     /**
      * Checks if a response message contains a body.
-     *
-     * @param requestMethod request method
-     * @param responseCode  response status code
-     * @return whether the response has a body
      * @see <a href="https://tools.ietf.org/html/rfc7230#section-3.3">RFC 7230 section 3.3</a>
+     * @param requestMethod request method
+     * @param responseCode response status code
+     * @return whether the response has a body
      */
     private static boolean hasResponseBody(int requestMethod, int responseCode) {
         return requestMethod != Request.Method.HEAD
@@ -145,7 +144,6 @@ public class HurlStack implements HttpStack {
 
     /**
      * Initializes an {@link HttpEntity} from the given {@link HttpURLConnection}.
-     *
      * @param connection
      * @return an HttpEntity populated with data from <code>connection</code>.
      */
@@ -180,7 +178,6 @@ public class HurlStack implements HttpStack {
 
     /**
      * Opens an {@link HttpURLConnection} with parameters.
-     *
      * @param url
      * @return an open connection
      * @throws IOException
@@ -196,7 +193,7 @@ public class HurlStack implements HttpStack {
 
         // use caller-provided custom SslSocketFactory, if any, for HTTPS
         if ("https".equals(url.getProtocol()) && mSslSocketFactory != null) {
-            ((HttpsURLConnection) connection).setSSLSocketFactory(mSslSocketFactory);
+            ((HttpsURLConnection)connection).setSSLSocketFactory(mSslSocketFactory);
         }
 
         return connection;
@@ -212,8 +209,9 @@ public class HurlStack implements HttpStack {
                 // GET.  Otherwise, it is assumed that the request is a POST.
                 byte[] postBody = request.getPostBody();
                 if (postBody != null) {
+                    connection.setDoOutput(true);
                     connection.setRequestMethod("POST");
-                    addBodyIfExists(connection, request, postBody);
+                    addBody(connection, request, postBody);
                 }
                 break;
             case Method.GET:
@@ -254,13 +252,12 @@ public class HurlStack implements HttpStack {
             throws IOException, AuthFailureError {
         byte[] body = request.getBody();
         if (body != null) {
-            addBodyIfExists(connection, request, body);
+            addBody(connection, request, body);
         }
     }
 
-    private static void addBodyIfExists(HttpURLConnection connection, Request<?> request, byte[] body)
+    private static void addBody(HttpURLConnection connection, Request<?> request, byte[] body)
             throws IOException, AuthFailureError {
-        if (body != null) {
             // Prepare output. There is no need to set Content-Length explicitly,
             // since this is handled by HttpURLConnection using the size of the prepared
             // output stream.
@@ -269,6 +266,5 @@ public class HurlStack implements HttpStack {
             DataOutputStream out = new DataOutputStream(connection.getOutputStream());
             out.write(body);
             out.close();
-        }
     }
 }


### PR DESCRIPTION
The legacy method was doing the exact same thing as `addIfBodyExists`. Now merged the two and added an override to support the different source of byte stream. Also formatted the file.