### PR TITLE
Support-multiple-identical-headers

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -16,6 +16,8 @@
 
 package com.android.volley.toolbox;
 
+import android.text.TextUtils;
+
 import com.android.volley.AuthFailureError;
 import com.android.volley.Request;
 import com.android.volley.Request.Method;
@@ -120,8 +122,10 @@ public class HurlStack implements HttpStack {
             response.setEntity(entityFromConnection(connection));
         }
         for (Entry<String, List<String>> header : connection.getHeaderFields().entrySet()) {
-            if (header.getKey() != null) {
-                Header h = new BasicHeader(header.getKey(), header.getValue().get(0));
+            if (header.getKey() != null)
+            {
+                String value = TextUtils.join(Volley.IDENTICAL_HEADER_SEPARATOR, header.getValue());
+                Header h = new BasicHeader(header.getKey(), value);
                 response.addHeader(h);
             }
         }

--- a/src/main/java/com/android/volley/toolbox/Volley.java
+++ b/src/main/java/com/android/volley/toolbox/Volley.java
@@ -32,6 +32,9 @@ public class Volley {
     /** Default on-disk cache directory. */
     private static final String DEFAULT_CACHE_DIR = "volley";
 
+    /** Separator for identical header */
+    public static final String IDENTICAL_HEADER_SEPARATOR = String.valueOf('\0');
+
     /**
      * Creates a default instance of the worker pool and calls {@link RequestQueue#start()} on it.
      *


### PR DESCRIPTION
I figured out that volley only gets the first value of the identical headers in an HTTP response. So the solution I presented is to concatenate the values of the header and separate them with a symbol.
This symbol is **"\0"** and stored in **Volley.IDENTICAL_HEADER_SEPARATOR**

Developer can easily get the values of the identicale header by splitting it using volley separator. 
`String cookies[] = response.get("Set-Cookie").split(Volley.IDENTICAL_HEADER_SEPARATOR);`