### PR TITLE
Check that deserialized string length in DiskBasedCache does not overflow int

### DIFF
--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -250,7 +250,6 @@ public class DiskBasedCacheTest {
     }
 
     @Test
-    @SuppressWarnings("TryFinallyCanBeTryWithResources")
     public void testStreamToBytesNegativeLength() throws IOException {
         byte[] data = new byte[1];
         CountingInputStream cis =
@@ -260,7 +259,6 @@ public class DiskBasedCacheTest {
     }
 
     @Test
-    @SuppressWarnings("TryFinallyCanBeTryWithResources")
     public void testStreamToBytesExcessiveLength() throws IOException {
         byte[] data = new byte[1];
         CountingInputStream cis =
@@ -270,7 +268,6 @@ public class DiskBasedCacheTest {
     }
 
     @Test
-    @SuppressWarnings("TryFinallyCanBeTryWithResources")
     public void testStreamToBytesOverflow() throws IOException {
         byte[] data = new byte[0];
         CountingInputStream cis =

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -273,7 +273,7 @@ public class DiskBasedCacheTest {
         CountingInputStream cis =
                 new CountingInputStream(new ByteArrayInputStream(data), 0x100000000L);
         exception.expect(IOException.class);
-        DiskBasedCache.streamToBytes(cis, 0x100000000L);
+        DiskBasedCache.streamToBytes(cis, 0x100000000L); // int value is 0
     }
 
     @Test


### PR DESCRIPTION
Changes:

* Strengthens the length validation in streamToBytes before casting long to int. This fails faster when deserializing a bad string length. (Issue #12 )
* Eliminates unvalidated `(int) long` casts, which improves code quality.

The overflow check is from Java 8's Math.toIntExact: `(int) length != length`

Unit test added. Without the added overflow check, the new test fails because the expected IOException is not thrown.