### PR TITLE
Fix regression introduced by #18.

### DIFF
--- a/src/main/java/com/android/volley/Cache.java
+++ b/src/main/java/com/android/volley/Cache.java
@@ -87,12 +87,12 @@ public interface Cache {
         public Map<String, String> responseHeaders = Collections.emptyMap();
 
         /** True if the entry is expired. */
-        boolean isExpired() {
+        public boolean isExpired() {
             return this.ttl < System.currentTimeMillis();
         }
 
         /** True if a refresh is needed from the original data source. */
-        boolean refreshNeeded() {
+        public boolean refreshNeeded() {
             return this.softTtl < System.currentTimeMillis();
         }
     }


### PR DESCRIPTION
Cache.Entry is a class, not an interface; its methods should never
have been made package-private as they were part of the public
Volley API.