### PR TITLE
Fix soft TTL for duplicate requests

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -71,7 +71,7 @@ public class CacheDispatcher extends Thread {
         mNetworkQueue = networkQueue;
         mCache = cache;
         mDelivery = delivery;
-	mWaitingRequestHandler = new WaitingRequestHandler(this);
+        mWaitingRequestHandler = new WaitingRequestHandler(this);
     }
 
     /**

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -218,9 +218,7 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
                         waitingRequests.size(), cacheKey);
                 }
                 Request<?> nextInLine = waitingRequests.remove();
-                if (waitingRequests.size() > 0) {
-                  mWaitingRequests.put(cacheKey, waitingRequests);
-                }
+                mWaitingRequests.put(cacheKey, waitingRequests);
                 try {
                     mNetworkQueue.put(nextInLine);
                 } catch (InterruptedException iex) {

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -33,7 +33,7 @@ import java.util.concurrent.BlockingQueue;
  * refresh are enqueued on the specified network queue for processing
  * by a {@link NetworkDispatcher}.
  */
-public class CacheDispatcher extends Thread implements Request.NetworkRequestCompleteListener {
+public class CacheDispatcher extends Thread {
 
     private static final boolean DEBUG = VolleyLog.DEBUG;
 
@@ -52,17 +52,8 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
     /** Used for telling us to die. */
     private volatile boolean mQuit = false;
 
-    /**
-     * Staging area for requests that already have a duplicate request in flight.
-     *
-     * <ul>
-     *     <li>containsKey(cacheKey) indicates that there is a request in flight for the given cache
-     *          key.</li>
-     *     <li>get(cacheKey) returns waiting requests for the given cache key. The in flight request
-     *          is <em>not</em> contained in that list. Is null if no requests are staged.</li>
-     * </ul>
-     */
-    private final Map<String, Queue<Request<?>>> mWaitingRequests = new HashMap<>();
+    /** Manage list of waiting requests and de-duplicate requests with same cache key. */
+    private WaitingRequestHandler mWaitingRequestHandler;
 
     /**
      * Creates a new cache triage dispatcher thread.  You must call {@link #start()}
@@ -80,6 +71,7 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
         mNetworkQueue = networkQueue;
         mCache = cache;
         mDelivery = delivery;
+	mWaitingRequestHandler = new WaitingRequestHandler();
     }
 
     /**
@@ -117,7 +109,7 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
                 if (entry == null) {
                     request.addMarker("cache-miss");
                     // Cache miss; send off to the network dispatcher.
-                    if (!maybeAddToWaitingRequests(request)) {
+                    if (!mWaitingRequestHandler.maybeAddToWaitingRequests(request)) {
                         mNetworkQueue.put(request);
                     }
                     continue;
@@ -127,7 +119,7 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
                 if (entry.isExpired()) {
                     request.addMarker("cache-hit-expired");
                     request.setCacheEntry(entry);
-                    if (!maybeAddToWaitingRequests(request)) {
+                    if (!mWaitingRequestHandler.maybeAddToWaitingRequests(request)) {
                         mNetworkQueue.put(request);
                     }
                     continue;
@@ -151,7 +143,7 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
                     // Mark the response as intermediate.
                     response.intermediate = true;
 
-                    if (!maybeAddToWaitingRequests(request)) {
+                    if (!mWaitingRequestHandler.maybeAddToWaitingRequests(request)) {
                         // Post the intermediate response back to the user and have
                         // the delivery then forward the request along to the network.
                         mDelivery.postResponse(request, response, new Runnable() {
@@ -181,94 +173,103 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
         }
     }
 
-    /** Request received a valid response that can be used by other waiting requests. */
-    @Override
-    public void onResponseReceived(Request<?> request, Response<?> response) {
-        if (response.cacheEntry == null || response.cacheEntry.isExpired()) {
-            onNoUsableResponseReceived(request);
-            return;
-        }
-        String cacheKey = request.getCacheKey();
-        Queue<Request<?>> waitingRequests;
-        synchronized (mWaitingRequests) {
-            waitingRequests = mWaitingRequests.remove(cacheKey);
-        }
-        if (waitingRequests != null) {
-            if (VolleyLog.DEBUG) {
-                VolleyLog.v("Releasing %d waiting requests for cacheKey=%s.",
-                    waitingRequests.size(), cacheKey);
-            }
-            // Process all queued up requests.
-            for (Request<?> waiting : waitingRequests) {
-                mDelivery.postResponse(waiting, response);
-            }
-        }
-    }
+    private class WaitingRequestHandler implements Request.NetworkRequestCompleteListener {
+	
+	/**
+	 * Staging area for requests that already have a duplicate request in flight.
+	 *
+	 * <ul>
+	 *     <li>containsKey(cacheKey) indicates that there is a request in flight for the given cache
+	 *          key.</li>
+	 *     <li>get(cacheKey) returns waiting requests for the given cache key. The in flight request
+	 *          is <em>not</em> contained in that list. Is null if no requests are staged.</li>
+	 * </ul>
+	 */
+	private final Map<String, Queue<Request<?>>> mWaitingRequests = new HashMap<>();
 
-    /** No valid response received from network, release waiting requests. */
-    @Override
-    public void onNoUsableResponseReceived(Request<?> request) {
-        String cacheKey = request.getCacheKey();
-        synchronized (mWaitingRequests) {
-            Queue<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
-            if (waitingRequests != null) {
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.v("%d waiting requests for cacheKey=%s; resend to network",
-                        waitingRequests.size(), cacheKey);
-                }
-                Request<?> nextInLine = waitingRequests.remove();
+	/** Request received a valid response that can be used by other waiting requests. */
+	@Override
+	public synchronized void onResponseReceived(Request<?> request, Response<?> response) {
+	    if (response.cacheEntry == null || response.cacheEntry.isExpired()) {
+		onNoUsableResponseReceived(request);
+		return;
+	    }
+	    String cacheKey = request.getCacheKey();
+	    Queue<Request<?>> waitingRequests;
+	    waitingRequests = mWaitingRequests.remove(cacheKey);
+	    if (waitingRequests != null) {
+		if (VolleyLog.DEBUG) {
+		    VolleyLog.v("Releasing %d waiting requests for cacheKey=%s.",
+				waitingRequests.size(), cacheKey);
+		}
+		// Process all queued up requests.
+		for (Request<?> waiting : waitingRequests) {
+		    mDelivery.postResponse(waiting, response);
+		}
+	    }
+	}
+
+	/** No valid response received from network, release waiting requests. */
+	@Override
+	public synchronized void onNoUsableResponseReceived(Request<?> request) {
+	    String cacheKey = request.getCacheKey();
+	    Queue<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
+	    if (waitingRequests != null) {
+		if (VolleyLog.DEBUG) {
+		    VolleyLog.v("%d waiting requests for cacheKey=%s; resend to network",
+				waitingRequests.size(), cacheKey);
+		}
+		Request<?> nextInLine = waitingRequests.remove();
 		if (nextInLine == null) {
 		    return;
 		}
-                mWaitingRequests.put(cacheKey, waitingRequests);
-                try {
-                    mNetworkQueue.put(nextInLine);
-                } catch (InterruptedException iex) {
-                    VolleyLog.e("Couldn't add request to queue. %s", iex.toString());
-                    // Restore the interrupted status of the calling thread (i.e. NetworkDIspatcher)
-                    Thread.currentThread().interrupt();
+		mWaitingRequests.put(cacheKey, waitingRequests);
+		try {
+		    mNetworkQueue.put(nextInLine);
+		} catch (InterruptedException iex) {
+		    VolleyLog.e("Couldn't add request to queue. %s", iex.toString());
+		    // Restore the interrupted status of the calling thread (i.e. NetworkDIspatcher)
+		    Thread.currentThread().interrupt();
 		    // Quit the current CacheDispatcher thread.
-                    quit();
-                }
-            }
-        }
-    }
+		    quit();
+		}
+	    }
+	}
 
-    /**
-     * For cacheable requests, if a request for the same cache key is already in flight,
-     * add it to a queue to wait for that in-flight request to finish.
-     * @return whether the request was queued. If false, we should continue issuing the request
-     * over the network. If true, we should put the request on hold to be processed when
-     * the in-flight request finishes.
-     */
-    private boolean maybeAddToWaitingRequests(Request<?> request) {
-        String cacheKey = request.getCacheKey();
-        synchronized (mWaitingRequests) {
-            // Insert request into stage if there's already a request with the same cache key
-            // in flight.
-            if (mWaitingRequests.containsKey(cacheKey)) {
-                // There is already a request in flight. Queue up.
-                Queue<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
-                if (stagedRequests == null) {
-                    stagedRequests = new LinkedList<Request<?>>();
-                }
-                request.addMarker("waiting-for-response");
-                stagedRequests.add(request);
-                mWaitingRequests.put(cacheKey, stagedRequests);
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.d("Request for cacheKey=%s is in flight, putting on hold.", cacheKey);
-                }
-                return true;
-            } else {
-                // Insert 'null' queue for this cacheKey, indicating there is now a request in
-                // flight.
-                mWaitingRequests.put(cacheKey, null);
-                request.setNetworkRequestCompleteListener(this);
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.d("new request, sending to network %s", cacheKey);
-                }
-                return false;
-            }
-        }
+	/**
+	 * For cacheable requests, if a request for the same cache key is already in flight,
+	 * add it to a queue to wait for that in-flight request to finish.
+	 * @return whether the request was queued. If false, we should continue issuing the request
+	 * over the network. If true, we should put the request on hold to be processed when
+	 * the in-flight request finishes.
+	 */
+	private synchronized boolean maybeAddToWaitingRequests(Request<?> request) {
+	    String cacheKey = request.getCacheKey();
+	    // Insert request into stage if there's already a request with the same cache key
+	    // in flight.
+	    if (mWaitingRequests.containsKey(cacheKey)) {
+		// There is already a request in flight. Queue up.
+		Queue<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
+		if (stagedRequests == null) {
+		    stagedRequests = new LinkedList<Request<?>>();
+		}
+		request.addMarker("waiting-for-response");
+		stagedRequests.add(request);
+		mWaitingRequests.put(cacheKey, stagedRequests);
+		if (VolleyLog.DEBUG) {
+		    VolleyLog.d("Request for cacheKey=%s is in flight, putting on hold.", cacheKey);
+		}
+		return true;
+	    } else {
+		// Insert 'null' queue for this cacheKey, indicating there is now a request in
+		// flight.
+		mWaitingRequests.put(cacheKey, null);
+		request.setNetworkRequestCompleteListener(this);
+		if (VolleyLog.DEBUG) {
+		    VolleyLog.d("new request, sending to network %s", cacheKey);
+		}
+		return false;
+	    }
+	}
     }
 }

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -53,7 +53,7 @@ public class CacheDispatcher extends Thread {
     private volatile boolean mQuit = false;
 
     /** Manage list of waiting requests and de-duplicate requests with same cache key. */
-    private final WaitingRequestHandler mWaitingRequestHandler;
+    private final WaitingRequestManager mWaitingRequestManager;
 
     /**
      * Creates a new cache triage dispatcher thread.  You must call {@link #start()}
@@ -71,7 +71,7 @@ public class CacheDispatcher extends Thread {
         mNetworkQueue = networkQueue;
         mCache = cache;
         mDelivery = delivery;
-        mWaitingRequestHandler = new WaitingRequestHandler(this);
+        mWaitingRequestManager = new WaitingRequestManager(this);
     }
 
     /**
@@ -109,7 +109,7 @@ public class CacheDispatcher extends Thread {
                 if (entry == null) {
                     request.addMarker("cache-miss");
                     // Cache miss; send off to the network dispatcher.
-                    if (!mWaitingRequestHandler.maybeAddToWaitingRequests(request)) {
+                    if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
                         mNetworkQueue.put(request);
                     }
                     continue;
@@ -119,7 +119,7 @@ public class CacheDispatcher extends Thread {
                 if (entry.isExpired()) {
                     request.addMarker("cache-hit-expired");
                     request.setCacheEntry(entry);
-                    if (!mWaitingRequestHandler.maybeAddToWaitingRequests(request)) {
+                    if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
                         mNetworkQueue.put(request);
                     }
                     continue;
@@ -143,7 +143,7 @@ public class CacheDispatcher extends Thread {
                     // Mark the response as intermediate.
                     response.intermediate = true;
 
-                    if (!mWaitingRequestHandler.maybeAddToWaitingRequests(request)) {
+                    if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
                         // Post the intermediate response back to the user and have
                         // the delivery then forward the request along to the network.
                         mDelivery.postResponse(request, response, new Runnable() {
@@ -173,108 +173,111 @@ public class CacheDispatcher extends Thread {
         }
     }
 
-    private static class WaitingRequestHandler implements Request.NetworkRequestCompleteListener {
-	
-	/**
-	 * Staging area for requests that already have a duplicate request in flight.
-	 *
-	 * <ul>
-	 *     <li>containsKey(cacheKey) indicates that there is a request in flight for the given cache
-	 *          key.</li>
-	 *     <li>get(cacheKey) returns waiting requests for the given cache key. The in flight request
-	 *          is <em>not</em> contained in that list. Is null if no requests are staged.</li>
-	 * </ul>
-	 */
-	private final Map<String, Queue<Request<?>>> mWaitingRequests = new HashMap<>();
+    private static class WaitingRequestManager implements Request.NetworkRequestCompleteListener {
 
-	private final CacheDispatcher mCacheDispatcher;
-	
-	WaitingRequestHandler(CacheDispatcher cacheDispatcher) {
-	    mCacheDispatcher = cacheDispatcher;
-	}
-	
-	/** Request received a valid response that can be used by other waiting requests. */
-	@Override
-	public synchronized void onResponseReceived(Request<?> request, Response<?> response) {
-	    if (response.cacheEntry == null || response.cacheEntry.isExpired()) {
-		onNoUsableResponseReceived(request);
-		return;
-	    }
-	    String cacheKey = request.getCacheKey();
-	    Queue<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
-	    if (waitingRequests != null) {
-		if (VolleyLog.DEBUG) {
-		    VolleyLog.v("Releasing %d waiting requests for cacheKey=%s.",
-				waitingRequests.size(), cacheKey);
-		}
-		// Process all queued up requests.
-		for (Request<?> waiting : waitingRequests) {
-		    mCacheDispatcher.mDelivery.postResponse(waiting, response);
-		}
-	    }
-	}
+        /**
+         * Staging area for requests that already have a duplicate request in flight.
+         *
+         * <ul>
+         *     <li>containsKey(cacheKey) indicates that there is a request in flight for the given cache
+         *          key.</li>
+         *     <li>get(cacheKey) returns waiting requests for the given cache key. The in flight request
+         *          is <em>not</em> contained in that list. Is null if no requests are staged.</li>
+         * </ul>
+         */
+        private final Map<String, Queue<Request<?>>> mWaitingRequests = new HashMap<>();
 
-	/** No valid response received from network, release waiting requests. */
-	@Override
-	public synchronized void onNoUsableResponseReceived(Request<?> request) {
-	    String cacheKey = request.getCacheKey();
-	    Queue<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
-	    if (waitingRequests != null) {
-		if (VolleyLog.DEBUG) {
-		    VolleyLog.v("%d waiting requests for cacheKey=%s; resend to network",
-				waitingRequests.size(), cacheKey);
-		}
-		Request<?> nextInLine = waitingRequests.remove();
-		if (nextInLine == null) {
-		    return;
-		}
-		mWaitingRequests.put(cacheKey, waitingRequests);
-		try {
-		    mCacheDispatcher.mNetworkQueue.put(nextInLine);
-		} catch (InterruptedException iex) {
-		    VolleyLog.e("Couldn't add request to queue. %s", iex.toString());
-		    // Restore the interrupted status of the calling thread (i.e. NetworkDIspatcher)
-		    Thread.currentThread().interrupt();
-		    // Quit the current CacheDispatcher thread.
-		    mCacheDispatcher.quit();
-		}
-	    }
-	}
+        private final CacheDispatcher mCacheDispatcher;
 
-	/**
-	 * For cacheable requests, if a request for the same cache key is already in flight,
-	 * add it to a queue to wait for that in-flight request to finish.
-	 * @return whether the request was queued. If false, we should continue issuing the request
-	 * over the network. If true, we should put the request on hold to be processed when
-	 * the in-flight request finishes.
-	 */
-	private synchronized boolean maybeAddToWaitingRequests(Request<?> request) {
-	    String cacheKey = request.getCacheKey();
-	    // Insert request into stage if there's already a request with the same cache key
-	    // in flight.
-	    if (mWaitingRequests.containsKey(cacheKey)) {
-		// There is already a request in flight. Queue up.
-		Queue<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
-		if (stagedRequests == null) {
-		    stagedRequests = new LinkedList<Request<?>>();
-		}
-		request.addMarker("waiting-for-response");
-		stagedRequests.add(request);
-		mWaitingRequests.put(cacheKey, stagedRequests);
-		if (VolleyLog.DEBUG) {
-		    VolleyLog.d("Request for cacheKey=%s is in flight, putting on hold.", cacheKey);
-		}
-		return true;
-	    } else {
-		// Insert 'null' queue for this cacheKey, indicating there is now a request in
-		// flight.
-		mWaitingRequests.put(cacheKey, null);
-		request.setNetworkRequestCompleteListener(this);
-		if (VolleyLog.DEBUG) {
-		    VolleyLog.d("new request, sending to network %s", cacheKey);
-		}
-		return false;
-	    }
-	}
+        WaitingRequestManager(CacheDispatcher cacheDispatcher) {
+            mCacheDispatcher = cacheDispatcher;
+        }
+
+        /** Request received a valid response that can be used by other waiting requests. */
+        @Override
+        public void onResponseReceived(Request<?> request, Response<?> response) {
+            if (response.cacheEntry == null || response.cacheEntry.isExpired()) {
+                onNoUsableResponseReceived(request);
+                return;
+            }
+            String cacheKey = request.getCacheKey();
+            Queue<Request<?>> waitingRequests;
+            synchronized (this) {
+                waitingRequests = mWaitingRequests.remove(cacheKey);
+            }
+            if (waitingRequests != null) {
+                if (VolleyLog.DEBUG) {
+                    VolleyLog.v("Releasing %d waiting requests for cacheKey=%s.",
+                            waitingRequests.size(), cacheKey);
+                }
+                // Process all queued up requests.
+                for (Request<?> waiting : waitingRequests) {
+                    mCacheDispatcher.mDelivery.postResponse(waiting, response);
+                }
+            }
+        }
+
+        /** No valid response received from network, release waiting requests. */
+        @Override
+        public synchronized void onNoUsableResponseReceived(Request<?> request) {
+            String cacheKey = request.getCacheKey();
+            Queue<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
+            if (waitingRequests != null) {
+                if (VolleyLog.DEBUG) {
+                    VolleyLog.v("%d waiting requests for cacheKey=%s; resend to network",
+                            waitingRequests.size(), cacheKey);
+                }
+                Request<?> nextInLine = waitingRequests.remove();
+                    if (nextInLine == null) {
+                        return;
+                    }
+                    mWaitingRequests.put(cacheKey, waitingRequests);
+                try {
+                    mCacheDispatcher.mNetworkQueue.put(nextInLine);
+                } catch (InterruptedException iex) {
+                    VolleyLog.e("Couldn't add request to queue. %s", iex.toString());
+                    // Restore the interrupted status of the calling thread (i.e. NetworkDispatcher)
+                    Thread.currentThread().interrupt();
+                    // Quit the current CacheDispatcher thread.
+                    mCacheDispatcher.quit();
+                }
+            }
+        }
+
+        /**
+         * For cacheable requests, if a request for the same cache key is already in flight,
+         * add it to a queue to wait for that in-flight request to finish.
+         * @return whether the request was queued. If false, we should continue issuing the request
+         * over the network. If true, we should put the request on hold to be processed when
+         * the in-flight request finishes.
+         */
+        private synchronized boolean maybeAddToWaitingRequests(Request<?> request) {
+            String cacheKey = request.getCacheKey();
+            // Insert request into stage if there's already a request with the same cache key
+            // in flight.
+            if (mWaitingRequests.containsKey(cacheKey)) {
+                // There is already a request in flight. Queue up.
+                Queue<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
+                if (stagedRequests == null) {
+                    stagedRequests = new LinkedList<Request<?>>();
+                }
+                request.addMarker("waiting-for-response");
+                stagedRequests.add(request);
+                mWaitingRequests.put(cacheKey, stagedRequests);
+                if (VolleyLog.DEBUG) {
+                    VolleyLog.d("Request for cacheKey=%s is in flight, putting on hold.", cacheKey);
+                }
+                return true;
+            } else {
+                // Insert 'null' queue for this cacheKey, indicating there is now a request in
+                // flight.
+                mWaitingRequests.put(cacheKey, null);
+                request.setNetworkRequestCompleteListener(this);
+                if (VolleyLog.DEBUG) {
+                    VolleyLog.d("new request, sending to network %s", cacheKey);
+                }
+                return false;
+            }
+        }
     }
 }

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -148,11 +148,10 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
                     // refreshing.
                     request.addMarker("cache-hit-refresh-needed");
                     request.setCacheEntry(entry);
+                    // Mark the response as intermediate.
                     response.intermediate = true;
 
                     if (!maybeAddToWaitingRequests(request)) {
-                        // Mark the response as intermediate.
-
                         // Post the intermediate response back to the user and have
                         // the delivery then forward the request along to the network.
                         mDelivery.postResponse(request, response, new Runnable() {
@@ -166,6 +165,8 @@ public class CacheDispatcher extends Thread implements Request.NetworkRequestCom
                             }
                         });
                     } else {
+                        // request has been added to list of waiting requests
+                        // to receive the network response from the first request once it returns.
                         mDelivery.postResponse(request, response);
                     }
                 }

--- a/src/main/java/com/android/volley/Request.java
+++ b/src/main/java/com/android/volley/Request.java
@@ -608,7 +608,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      */
     /* package */ void setNetworkRequestCompleteListener(
             NetworkRequestCompleteListener requestCompleteListener) {
-        synchronized(mLock) {
+        synchronized (mLock) {
             mRequestCompleteListener = requestCompleteListener;
         }
     }
@@ -619,7 +619,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * @param response received from the network
      */
     /* package */ void notifyListenerResponseReceived(Response<?> response) {
-        synchronized(mLock) {
+        synchronized (mLock) {
             if (mRequestCompleteListener != null) {
                mRequestCompleteListener.onResponseReceived(this, response);
             }
@@ -631,7 +631,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * a response which can be used for other, waiting requests.
      */
     /* package */ void notifyListenerResponseNotUsable() {
-        synchronized(mLock) {
+        synchronized (mLock) {
             if (mRequestCompleteListener != null) {
                 mRequestCompleteListener.onNoUsableResponseReceived(this);
             }

--- a/src/main/java/com/android/volley/Request.java
+++ b/src/main/java/com/android/volley/Request.java
@@ -56,6 +56,18 @@ public abstract class Request<T> implements Comparable<Request<T>> {
         int PATCH = 7;
     }
 
+    /**
+     * Callback to notify when the network request returns.
+     */
+    /* package */ interface NetworkRequestCompleteListener {
+
+        /** Callback when a network response has been received. */
+        void onResponseReceived(Request<?> request, Response<?> response);
+
+        /** Callback when request returns from network without valid response. */
+        void onNoUsableResponseReceived(Request<?> request);
+    }
+
     /** An event log tracing the lifetime of this request; for debugging. */
     private final MarkerLog mEventLog = MarkerLog.ENABLED ? new MarkerLog() : null;
 
@@ -104,6 +116,8 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
     /** An opaque token tagging this request; used for bulk cancellation. */
     private Object mTag;
+
+    private NetworkRequestCompleteListener mRequestCompleteListener;
 
     /**
      * Creates a new request with the given URL and error listener.  Note that
@@ -582,6 +596,36 @@ public abstract class Request<T> implements Comparable<Request<T>> {
         if (mErrorListener != null) {
             mErrorListener.onErrorResponse(error);
         }
+    }
+
+    /**
+     * {@link NetworkRequestCompleteListener} that will receive callbacks when the request
+     * returns from the network.
+     */
+    /* package */ void setNetworkRequestCompleteListener(
+            NetworkRequestCompleteListener requestCompleteListener) {
+        mRequestCompleteListener = requestCompleteListener;
+    }
+
+    /**
+     * Notify RequestCompleteListener that a valid response has been received which can be used
+     * for other, waiting requests.
+     * @param response received from the network
+     */
+    /* package */ void notifyListenerResponseReceived(Response<?> response) {
+        if (mRequestCompleteListener != null) {
+           mRequestCompleteListener.onResponseReceived(this, response);
+        }
+    }
+
+    /**
+     * Notify RequestCompleteListener that the network request did not result in a response
+     * which can be used for other, waiting requests.
+     */
+    /* package */ void notifyListenerResponseNotUsable() {
+         if (mRequestCompleteListener != null) {
+             mRequestCompleteListener.onNoUsableResponseReceived(this);
+         }
     }
 
     /**

--- a/src/main/java/com/android/volley/Request.java
+++ b/src/main/java/com/android/volley/Request.java
@@ -608,8 +608,8 @@ public abstract class Request<T> implements Comparable<Request<T>> {
     }
 
     /**
-     * Notify RequestCompleteListener that a valid response has been received which can be used
-     * for other, waiting requests.
+     * Notify NetworkRequestCompleteListener that a valid response has been received
+     * which can be used for other, waiting requests.
      * @param response received from the network
      */
     /* package */ void notifyListenerResponseReceived(Response<?> response) {
@@ -619,8 +619,8 @@ public abstract class Request<T> implements Comparable<Request<T>> {
     }
 
     /**
-     * Notify RequestCompleteListener that the network request did not result in a response
-     * which can be used for other, waiting requests.
+     * Notify NetworkRequestCompleteListener that the network request did not result in
+     * a response which can be used for other, waiting requests.
      */
     /* package */ void notifyListenerResponseNotUsable() {
          if (mRequestCompleteListener != null) {

--- a/src/main/java/com/android/volley/RequestQueue.java
+++ b/src/main/java/com/android/volley/RequestQueue.java
@@ -20,12 +20,8 @@ import android.os.Handler;
 import android.os.Looper;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,19 +43,6 @@ public class RequestQueue {
 
     /** Used for generating monotonically-increasing sequence numbers for requests. */
     private final AtomicInteger mSequenceGenerator = new AtomicInteger();
-
-    /**
-     * Staging area for requests that already have a duplicate request in flight.
-     *
-     * <ul>
-     *     <li>containsKey(cacheKey) indicates that there is a request in flight for the given cache
-     *          key.</li>
-     *     <li>get(cacheKey) returns waiting requests for the given cache key. The in flight request
-     *          is <em>not</em> contained in that list. Is null if no requests are staged.</li>
-     * </ul>
-     */
-    private final Map<String, Queue<Request<?>>> mWaitingRequests =
-            new HashMap<>();
 
     /**
      * The set of all requests currently being processed by this RequestQueue. A Request
@@ -240,37 +223,13 @@ public class RequestQueue {
             mNetworkQueue.add(request);
             return request;
         }
-
-        // Insert request into stage if there's already a request with the same cache key in flight.
-        synchronized (mWaitingRequests) {
-            String cacheKey = request.getCacheKey();
-            if (mWaitingRequests.containsKey(cacheKey)) {
-                // There is already a request in flight. Queue up.
-                Queue<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
-                if (stagedRequests == null) {
-                    stagedRequests = new LinkedList<>();
-                }
-                stagedRequests.add(request);
-                mWaitingRequests.put(cacheKey, stagedRequests);
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.v("Request for cacheKey=%s is in flight, putting on hold.", cacheKey);
-                }
-            } else {
-                // Insert 'null' queue for this cacheKey, indicating there is now a request in
-                // flight.
-                mWaitingRequests.put(cacheKey, null);
-                mCacheQueue.add(request);
-            }
-            return request;
-        }
-    }
+        mCacheQueue.add(request);
+        return request;
+     }
 
     /**
      * Called from {@link Request#finish(String)}, indicating that processing of the given request
      * has finished.
-     *
-     * <p>Releases waiting requests for <code>request.getCacheKey()</code> if
-     *      <code>request.shouldCache()</code>.</p>
      */
     <T> void finish(Request<T> request) {
         // Remove from the set of requests currently being processed.
@@ -283,21 +242,6 @@ public class RequestQueue {
           }
         }
 
-        if (request.shouldCache()) {
-            synchronized (mWaitingRequests) {
-                String cacheKey = request.getCacheKey();
-                Queue<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
-                if (waitingRequests != null) {
-                    if (VolleyLog.DEBUG) {
-                        VolleyLog.v("Releasing %d waiting requests for cacheKey=%s.",
-                                waitingRequests.size(), cacheKey);
-                    }
-                    // Process all queued up requests. They won't be considered as in flight, but
-                    // that's not a problem as the cache has been primed by 'request'.
-                    mCacheQueue.addAll(waitingRequests);
-                }
-            }
-        }
     }
 
     public  <T> void addRequestFinishedListener(RequestFinishedListener<T> listener) {

--- a/src/test/java/com/android/volley/CacheDispatcherTest.java
+++ b/src/test/java/com/android/volley/CacheDispatcherTest.java
@@ -112,4 +112,31 @@ public class CacheDispatcherTest {
         Request request = mNetworkQueue.take();
         assertSame(entry, request.getCacheEntry());
     }
+
+    @Test public void duplicateCacheMiss() throws Exception {
+        MockRequest secondRequest = new MockRequest();
+        mRequest.setSequence(1);
+        secondRequest.setSequence(2);
+        mCacheQueue.add(mRequest);
+        mCacheQueue.add(secondRequest);
+        mCacheQueue.waitUntilEmpty(TIMEOUT_MILLIS);
+        assertTrue(mNetworkQueue.size() == 1);
+        assertFalse(mDelivery.postResponse_called);
+    }
+
+    @Test public void duplicateSoftExpiredCacheHit() throws Exception {
+        Cache.Entry entry = CacheTestUtils.makeRandomCacheEntry(null, false, true);
+        mCache.setEntryToReturn(entry);
+
+        MockRequest secondRequest = new MockRequest();
+        mRequest.setSequence(1);
+        secondRequest.setSequence(2);
+
+        mCacheQueue.add(mRequest);
+        mCacheQueue.add(secondRequest);
+        mCacheQueue.waitUntilEmpty(TIMEOUT_MILLIS);
+
+        assertTrue(mNetworkQueue.size() == 1);
+        assertTrue(mDelivery.postResponse_calledNtimes == 2);
+    }
 }

--- a/src/test/java/com/android/volley/CacheDispatcherTest.java
+++ b/src/test/java/com/android/volley/CacheDispatcherTest.java
@@ -124,7 +124,7 @@ public class CacheDispatcherTest {
         assertFalse(mDelivery.postResponse_called);
     }
 
-    @Test public void duplicateSoftExpiredCacheHit() throws Exception {
+    @Test public void duplicateSoftExpiredCacheHit_failedRequest() throws Exception {
         Cache.Entry entry = CacheTestUtils.makeRandomCacheEntry(null, false, true);
         mCache.setEntryToReturn(entry);
 
@@ -138,5 +138,34 @@ public class CacheDispatcherTest {
 
         assertTrue(mNetworkQueue.size() == 1);
         assertTrue(mDelivery.postResponse_calledNtimes == 2);
+
+        Request request = mNetworkQueue.take();
+        request.notifyListenerResponseNotUsable();
+        // Second request should now be in network queue.
+        assertTrue(mNetworkQueue.size() == 1);
+        request = mNetworkQueue.take();
+        assertTrue(request.equals(secondRequest));
+    }
+
+    @Test public void duplicateSoftExpiredCacheHit_successfulRequest() throws Exception {
+        Cache.Entry entry = CacheTestUtils.makeRandomCacheEntry(null, false, true);
+        mCache.setEntryToReturn(entry);
+
+        MockRequest secondRequest = new MockRequest();
+        mRequest.setSequence(1);
+        secondRequest.setSequence(2);
+
+        mCacheQueue.add(mRequest);
+        mCacheQueue.add(secondRequest);
+        mCacheQueue.waitUntilEmpty(TIMEOUT_MILLIS);
+
+        assertTrue(mNetworkQueue.size() == 1);
+        assertTrue(mDelivery.postResponse_calledNtimes == 2);
+
+        Request request = mNetworkQueue.take();
+        request.notifyListenerResponseReceived(Response.success(null, entry));
+        // Second request should have delivered response.
+        assertTrue(mNetworkQueue.size() == 0);
+        assertTrue(mDelivery.postResponse_calledNtimes == 3);
     }
 }

--- a/src/test/java/com/android/volley/mock/MockResponseDelivery.java
+++ b/src/test/java/com/android/volley/mock/MockResponseDelivery.java
@@ -25,6 +25,7 @@ public class MockResponseDelivery implements ResponseDelivery {
 
     public boolean postResponse_called = false;
     public boolean postError_called = false;
+    public long postResponse_calledNtimes = 0;
 
     public boolean wasEitherResponseCalled() {
         return postResponse_called || postError_called;
@@ -34,12 +35,14 @@ public class MockResponseDelivery implements ResponseDelivery {
     @Override
     public void postResponse(Request<?> request, Response<?> response) {
         postResponse_called = true;
+        postResponse_calledNtimes++;
         responsePosted = response;
     }
 
     @Override
     public void postResponse(Request<?> request, Response<?> response, Runnable runnable) {
         postResponse_called = true;
+        postResponse_calledNtimes++;
         responsePosted = response;
         runnable.run();
     }


### PR DESCRIPTION
When a soft TTL cache entry exists, that response should be served immediately rather than having duplicate requests wait for the first request's network response. This is done by moving the list of waiting, duplicate requests from the RequestQueue to the CacheDispatcher.