### PR TITLE
For waiting requests, use ArrayList instead of LinkedList

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -228,10 +228,7 @@ public class CacheDispatcher extends Thread {
                             waitingRequests.size(), cacheKey);
                 }
                 Request<?> nextInLine = waitingRequests.remove(0);
-                    if (nextInLine == null) {
-                        return;
-                    }
-                    mWaitingRequests.put(cacheKey, waitingRequests);
+                mWaitingRequests.put(cacheKey, waitingRequests);
                 try {
                     mCacheDispatcher.mNetworkQueue.put(nextInLine);
                 } catch (InterruptedException iex) {

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -222,7 +222,7 @@ public class CacheDispatcher extends Thread {
         public synchronized void onNoUsableResponseReceived(Request<?> request) {
             String cacheKey = request.getCacheKey();
             List<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
-            if (waitingRequests != null) {
+            if (waitingRequests != null && !waitingRequests.isEmpty()) {
                 if (VolleyLog.DEBUG) {
                     VolleyLog.v("%d waiting requests for cacheKey=%s; resend to network",
                             waitingRequests.size(), cacheKey);


### PR DESCRIPTION
As discussed previously, ArrayList is preferred over LinkedList.