### PR TITLE
Fix RequestQueueIntegrationTest flakiness.

### DIFF
--- a/src/test/java/com/android/volley/RequestQueueIntegrationTest.java
+++ b/src/test/java/com/android/volley/RequestQueueIntegrationTest.java
@@ -22,29 +22,30 @@ import com.android.volley.mock.MockRequest;
 import com.android.volley.mock.ShadowSystemClock;
 import com.android.volley.toolbox.NoCache;
 import com.android.volley.utils.ImmediateResponseDelivery;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 
 /**
- * Integration tests for {@link RequestQueue}, that verify its behavior in conjunction with real dispatcher, queues and
- * Requests. Network is mocked out
+ * Integration tests for {@link RequestQueue} that verify its behavior in conjunction with real
+ * dispatcher, queues and Requests.
+ *
+ * <p>The Network is mocked out.
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {ShadowSystemClock.class})
@@ -52,6 +53,8 @@ public class RequestQueueIntegrationTest {
 
     private ResponseDelivery mDelivery;
     @Mock private Network mMockNetwork;
+    @Mock private RequestFinishedListener<byte[]> mMockListener;
+    @Mock private RequestFinishedListener<byte[]> mMockListener2;
 
     @Before public void setUp() throws Exception {
         mDelivery = new ImmediateResponseDelivery();
@@ -59,9 +62,10 @@ public class RequestQueueIntegrationTest {
     }
 
     @Test public void add_requestProcessedInCorrectOrder() throws Exception {
-        // Enqueue 2 requests with different cache keys, and different priorities. The second, higher priority request
-        // takes 20ms.
-        // Assert that first request is only handled after the first one has been parsed and delivered.
+        // Enqueue 2 requests with different cache keys, and different priorities. The second,
+        // higher priority request takes 20ms.
+        // Assert that the first request is only handled after the first one has been parsed and
+        // delivered.
         MockRequest lowerPriorityReq = new MockRequest();
         MockRequest higherPriorityReq = new MockRequest();
         lowerPriorityReq.setCacheKey("1");
@@ -69,7 +73,6 @@ public class RequestQueueIntegrationTest {
         lowerPriorityReq.setPriority(Priority.LOW);
         higherPriorityReq.setPriority(Priority.HIGH);
 
-        RequestFinishedListener listener = mock(RequestFinishedListener.class);
         Answer<NetworkResponse> delayAnswer = new Answer<NetworkResponse>() {
             @Override
             public NetworkResponse answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -77,37 +80,31 @@ public class RequestQueueIntegrationTest {
                 return mock(NetworkResponse.class);
             }
         };
-        //delay only for higher request
+        // delay only for higher request
         when(mMockNetwork.performRequest(higherPriorityReq)).thenAnswer(delayAnswer);
         when(mMockNetwork.performRequest(lowerPriorityReq)).thenReturn(mock(NetworkResponse.class));
 
         RequestQueue queue = new RequestQueue(new NoCache(), mMockNetwork, 1, mDelivery);
-        queue.addRequestFinishedListener(listener);
+        queue.addRequestFinishedListener(mMockListener);
         queue.add(lowerPriorityReq);
         queue.add(higherPriorityReq);
         queue.start();
 
-        // you cannot do strict order verification in combination with timeouts with mockito 1.9.5 :(
-        // as an alternative, first verify no requests have finished, while higherPriorityReq should be processing
-        verifyNoMoreInteractions(listener);
+        InOrder inOrder = inOrder(mMockListener);
         // verify higherPriorityReq goes through first
-        verify(listener, timeout(100)).onRequestFinished(higherPriorityReq);
+        inOrder.verify(mMockListener, timeout(10000)).onRequestFinished(higherPriorityReq);
         // verify lowerPriorityReq goes last
-        verify(listener, timeout(10)).onRequestFinished(lowerPriorityReq);
+        inOrder.verify(mMockListener, timeout(10000)).onRequestFinished(lowerPriorityReq);
+
         queue.stop();
     }
 
-    /**
-     * Asserts that requests with same cache key are processed in order.
-     *
-     * Needs to be an integration test because relies on complex interations between various queues
-     */
+    /** Asserts that requests with same cache key are processed in order. */
     @Test public void add_dedupeByCacheKey() throws Exception {
         // Enqueue 2 requests with the same cache key. The first request takes 20ms. Assert that the
         // second request is only handled after the first one has been parsed and delivered.
-        Request req1 = new MockRequest();
-        Request req2 = new MockRequest();
-        RequestFinishedListener listener = mock(RequestFinishedListener.class);
+        MockRequest req1 = new MockRequest();
+        MockRequest req2 = new MockRequest();
         Answer<NetworkResponse> delayAnswer = new Answer<NetworkResponse>() {
             @Override
             public NetworkResponse answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -120,27 +117,23 @@ public class RequestQueueIntegrationTest {
         when(mMockNetwork.performRequest(req2)).thenReturn(mock(NetworkResponse.class));
 
         RequestQueue queue = new RequestQueue(new NoCache(), mMockNetwork, 3, mDelivery);
-        queue.addRequestFinishedListener(listener);
+        queue.addRequestFinishedListener(mMockListener);
         queue.add(req1);
         queue.add(req2);
         queue.start();
 
-        // you cannot do strict order verification with mockito 1.9.5 :(
-        // as an alternative, first verify no requests have finished, then verify req1 goes through
-        verifyNoMoreInteractions(listener);
-        verify(listener, timeout(100)).onRequestFinished(req1);
-        verify(listener, timeout(10)).onRequestFinished(req2);
+        InOrder inOrder = inOrder(mMockListener);
+        // verify req1 goes through first
+        inOrder.verify(mMockListener, timeout(10000)).onRequestFinished(req1);
+        // verify req2 goes last
+        inOrder.verify(mMockListener, timeout(10000)).onRequestFinished(req2);
+
         queue.stop();
     }
 
-    /**
-     * Verify RequestFinishedListeners are informed when requests are canceled
-     *
-     * Needs to be an integration test because relies on Request -> dispatcher -> RequestQueue interaction
-     */
+    /** Verify RequestFinishedListeners are informed when requests are canceled.  */
     @Test public void add_requestFinishedListenerCanceled() throws Exception {
-        RequestFinishedListener listener = mock(RequestFinishedListener.class);
-        Request request = new MockRequest();
+        MockRequest request = new MockRequest();
         Answer<NetworkResponse> delayAnswer = new Answer<NetworkResponse>() {
             @Override
             public NetworkResponse answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -152,56 +145,43 @@ public class RequestQueueIntegrationTest {
 
         when(mMockNetwork.performRequest(request)).thenAnswer(delayAnswer);
 
-        queue.addRequestFinishedListener(listener);
+        queue.addRequestFinishedListener(mMockListener);
         queue.start();
         queue.add(request);
 
         request.cancel();
-        verify(listener, timeout(100)).onRequestFinished(request);
+        verify(mMockListener, timeout(10000)).onRequestFinished(request);
         queue.stop();
     }
 
-    /**
-     * Verify RequestFinishedListeners are informed when requests are successfully delivered
-     *
-     * Needs to be an integration test because relies on Request -> dispatcher -> RequestQueue interaction
-     */
+    /** Verify RequestFinishedListeners are informed when requests are successfully delivered. */
     @Test public void add_requestFinishedListenerSuccess() throws Exception {
-        NetworkResponse response = mock(NetworkResponse.class);
-        Request request = new MockRequest();
-        RequestFinishedListener listener = mock(RequestFinishedListener.class);
-        RequestFinishedListener listener2 = mock(RequestFinishedListener.class);
+        MockRequest request = new MockRequest();
         RequestQueue queue = new RequestQueue(new NoCache(), mMockNetwork, 1, mDelivery);
 
-        queue.addRequestFinishedListener(listener);
-        queue.addRequestFinishedListener(listener2);
+        queue.addRequestFinishedListener(mMockListener);
+        queue.addRequestFinishedListener(mMockListener2);
         queue.start();
         queue.add(request);
 
-        verify(listener, timeout(100)).onRequestFinished(request);
-        verify(listener2, timeout(100)).onRequestFinished(request);
+        verify(mMockListener, timeout(10000)).onRequestFinished(request);
+        verify(mMockListener2, timeout(10000)).onRequestFinished(request);
 
         queue.stop();
     }
 
-    /**
-     * Verify RequestFinishedListeners are informed when request errors
-     *
-     * Needs to be an integration test because relies on Request -> dispatcher -> RequestQueue interaction
-     */
+    /** Verify RequestFinishedListeners are informed when request errors. */
     @Test public void add_requestFinishedListenerError() throws Exception {
-        RequestFinishedListener listener = mock(RequestFinishedListener.class);
-        Request request = new MockRequest();
+        MockRequest request = new MockRequest();
         RequestQueue queue = new RequestQueue(new NoCache(), mMockNetwork, 1, mDelivery);
 
         when(mMockNetwork.performRequest(request)).thenThrow(new VolleyError());
 
-        queue.addRequestFinishedListener(listener);
+        queue.addRequestFinishedListener(mMockListener);
         queue.start();
         queue.add(request);
 
-        verify(listener, timeout(100)).onRequestFinished(request);
+        verify(mMockListener, timeout(10000)).onRequestFinished(request);
         queue.stop();
     }
-
 }


### PR DESCRIPTION
Test failures were due to listeners not being invoked fast enough by
background threads; the timeouts seem to have been aggressive to work
around an old Mockito limitation about not being able to verify the
order of calls. So migrate to new Mockito APIs that allow this, and
dramatically increase timeouts to try and avoid flakiness.

Fixes #56