### PR TITLE
Fix NPEs/compile errors introduced by header changes.

### DIFF
--- a/src/main/java/com/android/volley/NetworkResponse.java
+++ b/src/main/java/com/android/volley/NetworkResponse.java
@@ -35,7 +35,7 @@ public class NetworkResponse {
      * @param headers Headers returned with this response, or null for none
      * @param notModified True if the server returned a 304 and the data was already in cache
      * @param networkTimeMs Round-trip network time to receive network response
-     * @deprecated see {@link #NetworkResponse(int, byte[], List, boolean, long)}. This constructor
+     * @deprecated see {@link #NetworkResponse(int, byte[], boolean, long, List)}. This constructor
      *             cannot handle server responses containing multiple headers with the same name.
      *             This constructor may be removed in a future release of Volley.
      */
@@ -49,12 +49,12 @@ public class NetworkResponse {
      * Creates a new network response.
      * @param statusCode the HTTP status code
      * @param data Response body
-     * @param allHeaders All headers returned with this response, or null for none
      * @param notModified True if the server returned a 304 and the data was already in cache
      * @param networkTimeMs Round-trip network time to receive network response
+     * @param allHeaders All headers returned with this response, or null for none
      */
-    public NetworkResponse(int statusCode, byte[] data, List<Header> allHeaders,
-            boolean notModified, long networkTimeMs) {
+    public NetworkResponse(int statusCode, byte[] data, boolean notModified, long networkTimeMs,
+            List<Header> allHeaders) {
         this(statusCode, data, toHeaderMap(allHeaders), allHeaders, notModified, networkTimeMs);
     }
 
@@ -64,7 +64,7 @@ public class NetworkResponse {
      * @param data Response body
      * @param headers Headers returned with this response, or null for none
      * @param notModified True if the server returned a 304 and the data was already in cache
-     * @deprecated see {@link #NetworkResponse(int, byte[], List, boolean, long)}. This constructor
+     * @deprecated see {@link #NetworkResponse(int, byte[], boolean, long, List)}. This constructor
      *             cannot handle server responses containing multiple headers with the same name.
      *             This constructor may be removed in a future release of Volley.
      */
@@ -79,14 +79,14 @@ public class NetworkResponse {
      * @param data Response body
      */
     public NetworkResponse(byte[] data) {
-        this(HttpURLConnection.HTTP_OK, data, Collections.<Header>emptyList(), false, 0);
+        this(HttpURLConnection.HTTP_OK, data, false, 0, Collections.<Header>emptyList());
     }
 
     /**
      * Creates a new network response for an OK response.
      * @param data Response body
      * @param headers Headers returned with this response, or null for none
-     * @deprecated see {@link #NetworkResponse(int, byte[], List, boolean, long)}. This constructor
+     * @deprecated see {@link #NetworkResponse(int, byte[], boolean, long, List)}. This constructor
      *             cannot handle server responses containing multiple headers with the same name.
      *             This constructor may be removed in a future release of Volley.
      */
@@ -100,7 +100,11 @@ public class NetworkResponse {
         this.statusCode = statusCode;
         this.data = data;
         this.headers = headers;
-        this.allHeaders = Collections.unmodifiableList(allHeaders);
+        if (allHeaders == null) {
+            this.allHeaders = null;
+        } else {
+            this.allHeaders = Collections.unmodifiableList(allHeaders);
+        }
         this.notModified = notModified;
         this.networkTimeMs = networkTimeMs;
     }
@@ -132,6 +136,12 @@ public class NetworkResponse {
     public final long networkTimeMs;
 
     private static Map<String, String> toHeaderMap(List<Header> allHeaders) {
+        if (allHeaders == null) {
+            return null;
+        }
+        if (allHeaders.isEmpty()) {
+            return Collections.emptyMap();
+        }
         Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         // Later elements in the list take precedence.
         for (Header header : allHeaders) {
@@ -141,6 +151,12 @@ public class NetworkResponse {
     }
 
     private static List<Header> toAllHeaderList(Map<String, String> headers) {
+        if (headers == null) {
+            return null;
+        }
+        if (headers.isEmpty()) {
+            return Collections.emptyList();
+        }
         List<Header> allHeaders = new ArrayList<>(headers.size());
         for (Map.Entry<String, String> header : headers.entrySet()) {
             allHeaders.add(new Header(header.getKey(), header.getValue()));

--- a/src/main/java/com/android/volley/toolbox/AdaptedHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/AdaptedHttpStack.java
@@ -26,7 +26,6 @@ import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * {@link BaseHttpStack} implementation wrapping a {@link HttpStack}.

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -136,15 +136,13 @@ public class BasicNetwork implements Network {
                 if (statusCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
                     Entry entry = request.getCacheEntry();
                     if (entry == null) {
-                        return new NetworkResponse(HttpURLConnection.HTTP_NOT_MODIFIED, null,
-                                responseHeaders, true,
-                                SystemClock.elapsedRealtime() - requestStart);
+                        return new NetworkResponse(HttpURLConnection.HTTP_NOT_MODIFIED, null, true,
+                                SystemClock.elapsedRealtime() - requestStart, responseHeaders);
                     }
                     // Combine cached and response headers so the response will be complete.
                     List<Header> combinedHeaders = combineHeaders(responseHeaders, entry);
                     return new NetworkResponse(HttpURLConnection.HTTP_NOT_MODIFIED, entry.data,
-                            combinedHeaders, true,
-                            SystemClock.elapsedRealtime() - requestStart);
+                            true, SystemClock.elapsedRealtime() - requestStart, combinedHeaders);
                 }
 
                 // Some responses such as 204s do not have content.  We must check.
@@ -165,8 +163,8 @@ public class BasicNetwork implements Network {
                 if (statusCode < 200 || statusCode > 299) {
                     throw new IOException();
                 }
-                return new NetworkResponse(statusCode, responseContents, responseHeaders, false,
-                        SystemClock.elapsedRealtime() - requestStart);
+                return new NetworkResponse(statusCode, responseContents, false,
+                        SystemClock.elapsedRealtime() - requestStart, responseHeaders);
             } catch (SocketTimeoutException e) {
                 attemptRetryOnException("socket", request, new TimeoutError());
             } catch (MalformedURLException e) {
@@ -181,8 +179,8 @@ public class BasicNetwork implements Network {
                 VolleyLog.e("Unexpected response code %d for %s", statusCode, request.getUrl());
                 NetworkResponse networkResponse;
                 if (responseContents != null) {
-                    networkResponse = new NetworkResponse(statusCode, responseContents,
-                            responseHeaders, false, SystemClock.elapsedRealtime() - requestStart);
+                    networkResponse = new NetworkResponse(statusCode, responseContents, false,
+                            SystemClock.elapsedRealtime() - requestStart, responseHeaders);
                     if (statusCode == HttpURLConnection.HTTP_UNAUTHORIZED ||
                             statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
                         attemptRetryOnException("auth",

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -103,8 +103,6 @@ public class HurlStack extends BaseHttpStack {
             throw new IOException("Could not retrieve response code from HttpUrlConnection.");
         }
 
-
-
         if (!hasResponseBody(request.getMethod(), responseCode)) {
             return new HttpResponse(responseCode, convertHeaders(connection.getHeaderFields()));
         }
@@ -117,8 +115,12 @@ public class HurlStack extends BaseHttpStack {
     static List<Header> convertHeaders(Map<String, List<String>> responseHeaders) {
         List<Header> headerList = new ArrayList<>(responseHeaders.size());
         for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {
-            for (String value : entry.getValue()) {
-                headerList.add(new Header(entry.getKey(), value));
+            // HttpUrlConnection includes the status line as a header with a null key; omit it here
+            // since it's not really a header and the rest of Volley assumes non-null keys.
+            if (entry.getKey() != null) {
+                for (String value : entry.getValue()) {
+                    headerList.add(new Header(entry.getKey(), value));
+                }
             }
         }
         return headerList;

--- a/src/test/java/com/android/volley/NetworkResponseTest.java
+++ b/src/test/java/com/android/volley/NetworkResponseTest.java
@@ -1,0 +1,63 @@
+package com.android.volley;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+public class NetworkResponseTest {
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void mapToList() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("key1", "value1");
+        headers.put("key2", "value2");
+
+        NetworkResponse resp = new NetworkResponse(200, null, headers, false);
+
+        List<Header> expectedHeaders = new ArrayList<>();
+        expectedHeaders.add(new Header("key1", "value1"));
+        expectedHeaders.add(new Header("key2", "value2"));
+
+        assertThat(expectedHeaders,
+                containsInAnyOrder(resp.allHeaders.toArray(new Header[resp.allHeaders.size()])));
+    }
+
+    @Test
+    public void listToMap() {
+        List<Header> headers = new ArrayList<>();
+        headers.add(new Header("key1", "value1"));
+        // Later values should be preferred.
+        headers.add(new Header("key2", "ignoredvalue"));
+        headers.add(new Header("key2", "value2"));
+
+        NetworkResponse resp = new NetworkResponse(200, null, false, 0L, headers);
+
+        Map<String, String> expectedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        expectedHeaders.put("key1", "value1");
+        expectedHeaders.put("key2", "value2");
+
+        assertEquals(expectedHeaders, resp.headers);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void nullValuesDontCrash() {
+        new NetworkResponse(null);
+        new NetworkResponse(null, null);
+        new NetworkResponse(200, null, null, false);
+        new NetworkResponse(200, null, null, false, 0L);
+        new NetworkResponse(200, null, false, 0L, null);
+    }
+}

--- a/src/test/java/com/android/volley/toolbox/HttpHeaderParserTest.java
+++ b/src/test/java/com/android/volley/toolbox/HttpHeaderParserTest.java
@@ -279,7 +279,7 @@ public class HttpHeaderParserTest {
         headers.add(new Header("cache-control", "public, max-age=86400"));
         headers.add(new Header("content-type", "text/plain"));
 
-        NetworkResponse response = new NetworkResponse(0, null, headers, false, 0);
+        NetworkResponse response = new NetworkResponse(0, null, false, 0, headers);
         Cache.Entry entry = HttpHeaderParser.parseCacheHeaders(response);
 
         assertNotNull(entry);

--- a/src/test/java/com/android/volley/toolbox/HurlStackTest.java
+++ b/src/test/java/com/android/volley/toolbox/HurlStackTest.java
@@ -162,6 +162,7 @@ public class HurlStackTest {
 
     @Test public void convertHeaders() {
         Map<String, List<String>> headers = new HashMap<>();
+        headers.put(null, Collections.singletonList("Ignored"));
         headers.put("HeaderA", Collections.singletonList("ValueA"));
         List<String> values = new ArrayList<>();
         values.add("ValueB_1");


### PR DESCRIPTION
- NetworkResponse constructors are documented as accepting null maps,
so they should actually do so.
- The new NetworkResponse constructor was ambiguous with the old one
when "null" is provided as the headers, which breaks compile-time
backwards compatibility. Reorder the arguments in the new constructor
to work around this.
- HurlStack previously stripped out headers with null names, which was
critical as HttpUrlConnection returns the status line in this manner.
Reintroduce this filter.

Unit tests added to catch regressions here in the future.

Fixes #95