### PR TITLE
Fix an issue when the first request returns an error.

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -229,6 +229,7 @@ public class CacheDispatcher extends Thread {
                 }
                 Request<?> nextInLine = waitingRequests.remove(0);
                 mWaitingRequests.put(cacheKey, waitingRequests);
+                nextInLine.setNetworkRequestCompleteListener(this);
                 try {
                     mCacheDispatcher.mNetworkQueue.put(nextInLine);
                 } catch (InterruptedException iex) {


### PR DESCRIPTION
 The next waiting request was sent to the network without the Listener set. Added Listener for callback to release waiting requests.