### PR TITLE
Improve request cancelation handling.

### DIFF
--- a/src/main/java/com/android/volley/ExecutorDelivery.java
+++ b/src/main/java/com/android/volley/ExecutorDelivery.java
@@ -88,31 +88,7 @@ public class ExecutorDelivery implements ResponseDelivery {
         @SuppressWarnings("unchecked")
         @Override
         public void run() {
-            // If this request has canceled, finish it and don't deliver.
-            if (mRequest.isCanceled()) {
-                mRequest.finish("canceled-at-delivery");
-                return;
-            }
-
-            // Deliver a normal response or error, depending.
-            if (mResponse.isSuccess()) {
-                mRequest.deliverResponse(mResponse.result);
-            } else {
-                mRequest.deliverError(mResponse.error);
-            }
-
-            // If this is an intermediate response, add a marker, otherwise we're done
-            // and the request can be finished.
-            if (mResponse.intermediate) {
-                mRequest.addMarker("intermediate-response");
-            } else {
-                mRequest.finish("done");
-            }
-
-            // If we have been provided a post-delivery runnable, run it.
-            if (mRunnable != null) {
-                mRunnable.run();
-            }
+            mRequest.deliverResponse(mResponse, mRunnable);
        }
     }
 }

--- a/src/main/java/com/android/volley/toolbox/ImageRequest.java
+++ b/src/main/java/com/android/volley/toolbox/ImageRequest.java
@@ -42,7 +42,7 @@ public class ImageRequest extends Request<Bitmap> {
     /** Default backoff multiplier for image requests */
     public static final float DEFAULT_IMAGE_BACKOFF_MULT = 2f;
 
-    private final Response.Listener<Bitmap> mListener;
+    private Response.Listener<Bitmap> mListener;
     private final Config mDecodeConfig;
     private final int mMaxWidth;
     private final int mMaxHeight;
@@ -219,6 +219,11 @@ public class ImageRequest extends Request<Bitmap> {
         if (mListener != null) {
             mListener.onResponse(response);
         }
+    }
+
+    @Override
+    protected void onCanceled() {
+        mListener = null;
     }
 
     /**

--- a/src/main/java/com/android/volley/toolbox/JsonRequest.java
+++ b/src/main/java/com/android/volley/toolbox/JsonRequest.java
@@ -39,7 +39,7 @@ public abstract class JsonRequest<T> extends Request<T> {
     private static final String PROTOCOL_CONTENT_TYPE =
         String.format("application/json; charset=%s", PROTOCOL_CHARSET);
 
-    private final Listener<T> mListener;
+    private Listener<T> mListener;
     private final String mRequestBody;
 
     /**
@@ -66,6 +66,11 @@ public abstract class JsonRequest<T> extends Request<T> {
         if (mListener != null) {
             mListener.onResponse(response);
         }
+    }
+
+    @Override
+    protected void onCanceled() {
+        mListener = null;
     }
 
     @Override

--- a/src/main/java/com/android/volley/toolbox/StringRequest.java
+++ b/src/main/java/com/android/volley/toolbox/StringRequest.java
@@ -28,7 +28,7 @@ import java.io.UnsupportedEncodingException;
  * A canned request for retrieving the response body at a given URL as a String.
  */
 public class StringRequest extends Request<String> {
-    private final Listener<String> mListener;
+    private Listener<String> mListener;
 
     /**
      * Creates a new request with the given method.
@@ -60,6 +60,11 @@ public class StringRequest extends Request<String> {
         if (mListener != null) {
             mListener.onResponse(response);
         }
+    }
+
+    @Override
+    protected void onCanceled() {
+        mListener = null;
     }
 
     @Override

--- a/src/test/java/com/android/volley/RequestTest.java
+++ b/src/test/java/com/android/volley/RequestTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
@@ -43,6 +45,24 @@ public class RequestTest {
         assertTrue(low.compareTo(low2) < 0);
         assertTrue(low.compareTo(immediate) > 0);
         assertTrue(immediate.compareTo(high) < 0);
+    }
+
+    @Test public void cancelListener() {
+        TestRequest request = new TestRequest(Priority.NORMAL);
+        final AtomicBoolean listenerCalled = new AtomicBoolean(false);
+        request.setCancelListener(new Request.CancelListener() {
+            @Override
+            public void onRequestCanceled() {
+                listenerCalled.set(true);
+            }
+        });
+        assertFalse(request.isCanceled());
+        assertFalse(listenerCalled.get());
+
+        request.cancel();
+
+        assertTrue(request.isCanceled());
+        assertTrue(listenerCalled.get());
     }
 
     private class TestRequest extends Request<Object> {

--- a/src/test/java/com/android/volley/toolbox/RequestFutureTest.java
+++ b/src/test/java/com/android/volley/toolbox/RequestFutureTest.java
@@ -17,9 +17,14 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.Request;
+import com.android.volley.mock.MockRequest;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -31,5 +36,27 @@ public class RequestFutureTest {
         // Catch-all test to find API-breaking changes.
         assertNotNull(RequestFuture.class.getMethod("newFuture"));
         assertNotNull(RequestFuture.class.getMethod("setRequest", Request.class));
+    }
+
+    @Test(expected = CancellationException.class)
+    public void cancelRequest() throws Exception {
+        MockRequest request = new MockRequest();
+        RequestFuture<String> future = RequestFuture.newFuture();
+        future.setRequest(request);
+
+        request.cancel();
+
+        future.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = CancellationException.class)
+    public void cancelFuture() throws Exception {
+        MockRequest request = new MockRequest();
+        RequestFuture<String> future = RequestFuture.newFuture();
+        future.setRequest(request);
+
+        future.cancel(true);
+
+        future.get(5, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
- Provide stronger thread safety guarantees by locking access to any
variable which can be mutated during the processing of a request (i.e.
by the CacheDispatcher/NetworkDispatcher threads) and dispatching
response callbacks while holding the same lock that is held when
setting mCanceled. Unfortunately there's not much we can do about
alternative ResponseDelivery mechanisms, which are hopefully rare.

- Add a cancel listener interface and use it to prevent RequestFuture
from blocking for the complete timeout (or indefinitely) if a request
is canceled.

- Since listeners are often Android component classes like Activitys,
clear them upon cancellation. Unfortunately, this must be done in each
Request subclass to work, assuming the subclass follows the standard
pattern of holding the response listener as a member. But this enables
concerned apps to resolve this leak.

Fixes #15
Fixes #85