### PR TITLE
Bump from 1.0.1-SNAPSHOT to 1.1.0-SNAPSHOT.

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -17,7 +17,7 @@ apply plugin: 'maven-publish'
 
 def bintrayInfoFilePath = "$buildDir/outputs/bintray-descriptor.bintray-info.json"
 
-project.ext.version = '1.0.1-SNAPSHOT'
+project.ext.version = '1.1.0-SNAPSHOT'
 
 task sourcesJar(type: Jar) {
     classifier = 'sources'


### PR DESCRIPTION
Since this release introduces new APIs to support migrating off Apache
HTTP and handling multiple headers, the minor version should be
bumped. These changes are all backwards compatible so there is no need
to bump the major version.