### PR TITLE
Fixes Unchecked assignment: 'com.android.volley.RequestQueue.RequestFinishedListener' to 'com.android.volley.RequestQueue.RequestFinishedListener<T>

### DIFF
--- a/src/main/java/com/android/volley/RequestQueue.java
+++ b/src/main/java/com/android/volley/RequestQueue.java
@@ -38,7 +38,7 @@ public class RequestQueue<T> {
     /** Callback interface for completed requests. */
     public interface RequestFinishedListener<S> {
         /** Called when a request has finished processing. */
-        void onRequestFinished(Request<S> request);
+        void onRequestFinished(Request<? extends S> request);
     }
 
     /** Used for generating monotonically-increasing sequence numbers for requests. */
@@ -49,7 +49,7 @@ public class RequestQueue<T> {
      * will be in this set if it is waiting in any queue or currently being processed by
      * any dispatcher.
      */
-    private final Set<Request<?>> mCurrentRequests = new HashSet<Request<?>>();
+    private final Set<Request<?>> mCurrentRequests = new HashSet<>();
 
     /** The cache triage queue. */
     private final PriorityBlockingQueue<Request<?>> mCacheQueue =
@@ -77,7 +77,7 @@ public class RequestQueue<T> {
     /** The cache dispatcher. */
     private CacheDispatcher mCacheDispatcher;
 
-    private final List<RequestFinishedListener> mFinishedListeners =
+    private final List<RequestFinishedListener<? super T>> mFinishedListeners =
             new ArrayList<>();
 
     /**
@@ -237,14 +237,14 @@ public class RequestQueue<T> {
             mCurrentRequests.remove(request);
         }
         synchronized (mFinishedListeners) {
-          for (RequestFinishedListener listener : mFinishedListeners) {
+          for (RequestFinishedListener<? super T> listener : mFinishedListeners) {
             listener.onRequestFinished(request);
           }
         }
 
     }
 
-    public void addRequestFinishedListener(RequestFinishedListener<? extends T> listener) {
+    public void addRequestFinishedListener(RequestFinishedListener<? super T> listener) {
       synchronized (mFinishedListeners) {
         mFinishedListeners.add(listener);
       }
@@ -253,7 +253,7 @@ public class RequestQueue<T> {
     /**
      * Remove a RequestFinishedListener. Has no effect if listener was not previously added.
      */
-    public void removeRequestFinishedListener(RequestFinishedListener<? extends T> listener) {
+    public void removeRequestFinishedListener(RequestFinishedListener<? super T> listener) {
       synchronized (mFinishedListeners) {
         mFinishedListeners.remove(listener);
       }

--- a/src/main/java/com/android/volley/RequestQueue.java
+++ b/src/main/java/com/android/volley/RequestQueue.java
@@ -33,12 +33,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * resolving from either cache or network on a worker thread, and then delivering
  * a parsed response on the main thread.
  */
-public class RequestQueue {
+public class RequestQueue<T> {
 
     /** Callback interface for completed requests. */
-    public interface RequestFinishedListener<T> {
+    public interface RequestFinishedListener<S> {
         /** Called when a request has finished processing. */
-        void onRequestFinished(Request<T> request);
+        void onRequestFinished(Request<S> request);
     }
 
     /** Used for generating monotonically-increasing sequence numbers for requests. */
@@ -207,7 +207,7 @@ public class RequestQueue {
      * @param request The request to service
      * @return The passed-in request
      */
-    public <T> Request<T> add(Request<T> request) {
+    public Request<? extends T> add(Request<? extends T> request) {
         // Tag the request as belonging to this queue and add it to the set of current requests.
         request.setRequestQueue(this);
         synchronized (mCurrentRequests) {
@@ -231,20 +231,20 @@ public class RequestQueue {
      * Called from {@link Request#finish(String)}, indicating that processing of the given request
      * has finished.
      */
-    <T> void finish(Request<T> request) {
+     void finish(Request<? extends T> request) {
         // Remove from the set of requests currently being processed.
         synchronized (mCurrentRequests) {
             mCurrentRequests.remove(request);
         }
         synchronized (mFinishedListeners) {
-          for (RequestFinishedListener<T> listener : mFinishedListeners) {
+          for (RequestFinishedListener listener : mFinishedListeners) {
             listener.onRequestFinished(request);
           }
         }
 
     }
 
-    public  <T> void addRequestFinishedListener(RequestFinishedListener<T> listener) {
+    public void addRequestFinishedListener(RequestFinishedListener<? extends T> listener) {
       synchronized (mFinishedListeners) {
         mFinishedListeners.add(listener);
       }
@@ -253,7 +253,7 @@ public class RequestQueue {
     /**
      * Remove a RequestFinishedListener. Has no effect if listener was not previously added.
      */
-    public  <T> void removeRequestFinishedListener(RequestFinishedListener<T> listener) {
+    public void removeRequestFinishedListener(RequestFinishedListener<? extends T> listener) {
       synchronized (mFinishedListeners) {
         mFinishedListeners.remove(listener);
       }


### PR DESCRIPTION
previously in RequestQueue.java the methods: add(), finish(), addRequestFinishedListener(), removeRequestFinishedListener() all define their own method level generic types, which makes the type of RequestFinishedListener<> unchecked - reported by compiler.

This commit creates a class level generic type T for RequestQueue.java and complies with PECS (Producer Extends Consumer Super) principles.