### PR TITLE
Workaround memory leak in dispatchers.

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -93,82 +93,88 @@ public class CacheDispatcher extends Thread {
 
         while (true) {
             try {
-                // Get a request from the cache triage queue, blocking until
-                // at least one is available.
-                final Request<?> request = mCacheQueue.take();
-                request.addMarker("cache-queue-take");
-
-                // If the request has been canceled, don't bother dispatching it.
-                if (request.isCanceled()) {
-                    request.finish("cache-discard-canceled");
-                    continue;
-                }
-
-                // Attempt to retrieve this item from cache.
-                Cache.Entry entry = mCache.get(request.getCacheKey());
-                if (entry == null) {
-                    request.addMarker("cache-miss");
-                    // Cache miss; send off to the network dispatcher.
-                    if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
-                        mNetworkQueue.put(request);
-                    }
-                    continue;
-                }
-
-                // If it is completely expired, just send it to the network.
-                if (entry.isExpired()) {
-                    request.addMarker("cache-hit-expired");
-                    request.setCacheEntry(entry);
-                    if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
-                        mNetworkQueue.put(request);
-                    }
-                    continue;
-                }
-
-                // We have a cache hit; parse its data for delivery back to the request.
-                request.addMarker("cache-hit");
-                Response<?> response = request.parseNetworkResponse(
-                        new NetworkResponse(entry.data, entry.responseHeaders));
-                request.addMarker("cache-hit-parsed");
-
-                if (!entry.refreshNeeded()) {
-                    // Completely unexpired cache hit. Just deliver the response.
-                    mDelivery.postResponse(request, response);
-                } else {
-                    // Soft-expired cache hit. We can deliver the cached response,
-                    // but we need to also send the request to the network for
-                    // refreshing.
-                    request.addMarker("cache-hit-refresh-needed");
-                    request.setCacheEntry(entry);
-                    // Mark the response as intermediate.
-                    response.intermediate = true;
-
-                    if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
-                        // Post the intermediate response back to the user and have
-                        // the delivery then forward the request along to the network.
-                        mDelivery.postResponse(request, response, new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    mNetworkQueue.put(request);
-                                } catch (InterruptedException e) {
-                                    // Restore the interrupted status
-                                    Thread.currentThread().interrupt();
-                                }
-                            }
-                        });
-                    } else {
-                        // request has been added to list of waiting requests
-                        // to receive the network response from the first request once it returns.
-                        mDelivery.postResponse(request, response);
-                    }
-                }
-
+                processRequest();
             } catch (InterruptedException e) {
                 // We may have been interrupted because it was time to quit.
                 if (mQuit) {
                     return;
                 }
+            }
+        }
+    }
+
+    // Extracted to its own method to ensure locals have a constrained liveness scope by the GC.
+    // This is needed to avoid keeping previous request references alive for an indeterminate amount
+    // of time. See also https://github.com/google/volley/issues/114
+    private void processRequest() throws InterruptedException {
+        // Get a request from the cache triage queue, blocking until
+        // at least one is available.
+        final Request<?> request = mCacheQueue.take();
+        request.addMarker("cache-queue-take");
+
+        // If the request has been canceled, don't bother dispatching it.
+        if (request.isCanceled()) {
+            request.finish("cache-discard-canceled");
+            return;
+        }
+
+        // Attempt to retrieve this item from cache.
+        Cache.Entry entry = mCache.get(request.getCacheKey());
+        if (entry == null) {
+            request.addMarker("cache-miss");
+            // Cache miss; send off to the network dispatcher.
+            if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
+                mNetworkQueue.put(request);
+            }
+            return;
+        }
+
+        // If it is completely expired, just send it to the network.
+        if (entry.isExpired()) {
+            request.addMarker("cache-hit-expired");
+            request.setCacheEntry(entry);
+            if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
+                mNetworkQueue.put(request);
+            }
+            return;
+        }
+
+        // We have a cache hit; parse its data for delivery back to the request.
+        request.addMarker("cache-hit");
+        Response<?> response = request.parseNetworkResponse(
+                new NetworkResponse(entry.data, entry.responseHeaders));
+        request.addMarker("cache-hit-parsed");
+
+        if (!entry.refreshNeeded()) {
+            // Completely unexpired cache hit. Just deliver the response.
+            mDelivery.postResponse(request, response);
+        } else {
+            // Soft-expired cache hit. We can deliver the cached response,
+            // but we need to also send the request to the network for
+            // refreshing.
+            request.addMarker("cache-hit-refresh-needed");
+            request.setCacheEntry(entry);
+            // Mark the response as intermediate.
+            response.intermediate = true;
+
+            if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
+                // Post the intermediate response back to the user and have
+                // the delivery then forward the request along to the network.
+                mDelivery.postResponse(request, response, new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            mNetworkQueue.put(request);
+                        } catch (InterruptedException e) {
+                            // Restore the interrupted status
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                });
+            } else {
+                // request has been added to list of waiting requests
+                // to receive the network response from the first request once it returns.
+                mDelivery.postResponse(request, response);
             }
         }
     }

--- a/src/main/java/com/android/volley/NetworkDispatcher.java
+++ b/src/main/java/com/android/volley/NetworkDispatcher.java
@@ -83,70 +83,75 @@ public class NetworkDispatcher extends Thread {
     public void run() {
         Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
         while (true) {
-            long startTimeMs = SystemClock.elapsedRealtime();
-            Request<?> request;
             try {
-                // Take a request from the queue.
-                request = mQueue.take();
+                processRequest();
             } catch (InterruptedException e) {
                 // We may have been interrupted because it was time to quit.
                 if (mQuit) {
                     return;
                 }
-                continue;
+            }
+        }
+    }
+
+    // Extracted to its own method to ensure locals have a constrained liveness scope by the GC.
+    // This is needed to avoid keeping previous request references alive for an indeterminate amount
+    // of time. See also https://github.com/google/volley/issues/114
+    private void processRequest() throws InterruptedException {
+        long startTimeMs = SystemClock.elapsedRealtime();
+        // Take a request from the queue.
+        Request<?> request = mQueue.take();
+
+        try {
+            request.addMarker("network-queue-take");
+
+            // If the request was cancelled already, do not perform the
+            // network request.
+            if (request.isCanceled()) {
+                request.finish("network-discard-cancelled");
+                request.notifyListenerResponseNotUsable();
+                return;
             }
 
-            try {
-                request.addMarker("network-queue-take");
+            addTrafficStatsTag(request);
 
-                // If the request was cancelled already, do not perform the
-                // network request.
-                if (request.isCanceled()) {
-                    request.finish("network-discard-cancelled");
-                    request.notifyListenerResponseNotUsable();
-                    continue;
-                }
+            // Perform the network request.
+            NetworkResponse networkResponse = mNetwork.performRequest(request);
+            request.addMarker("network-http-complete");
 
-                addTrafficStatsTag(request);
-
-                // Perform the network request.
-                NetworkResponse networkResponse = mNetwork.performRequest(request);
-                request.addMarker("network-http-complete");
-
-                // If the server returned 304 AND we delivered a response already,
-                // we're done -- don't deliver a second identical response.
-                if (networkResponse.notModified && request.hasHadResponseDelivered()) {
-                    request.finish("not-modified");
-                    request.notifyListenerResponseNotUsable();
-                    continue;
-                }
-
-                // Parse the response here on the worker thread.
-                Response<?> response = request.parseNetworkResponse(networkResponse);
-                request.addMarker("network-parse-complete");
-
-                // Write to cache if applicable.
-                // TODO: Only update cache metadata instead of entire record for 304s.
-                if (request.shouldCache() && response.cacheEntry != null) {
-                    mCache.put(request.getCacheKey(), response.cacheEntry);
-                    request.addMarker("network-cache-written");
-                }
-
-                // Post the response back.
-                request.markDelivered();
-                mDelivery.postResponse(request, response);
-                request.notifyListenerResponseReceived(response);
-            } catch (VolleyError volleyError) {
-                volleyError.setNetworkTimeMs(SystemClock.elapsedRealtime() - startTimeMs);
-                parseAndDeliverNetworkError(request, volleyError);
+            // If the server returned 304 AND we delivered a response already,
+            // we're done -- don't deliver a second identical response.
+            if (networkResponse.notModified && request.hasHadResponseDelivered()) {
+                request.finish("not-modified");
                 request.notifyListenerResponseNotUsable();
-            } catch (Exception e) {
-                VolleyLog.e(e, "Unhandled exception %s", e.toString());
-                VolleyError volleyError = new VolleyError(e);
-                volleyError.setNetworkTimeMs(SystemClock.elapsedRealtime() - startTimeMs);
-                mDelivery.postError(request, volleyError);
-                request.notifyListenerResponseNotUsable();
+                return;
             }
+
+            // Parse the response here on the worker thread.
+            Response<?> response = request.parseNetworkResponse(networkResponse);
+            request.addMarker("network-parse-complete");
+
+            // Write to cache if applicable.
+            // TODO: Only update cache metadata instead of entire record for 304s.
+            if (request.shouldCache() && response.cacheEntry != null) {
+                mCache.put(request.getCacheKey(), response.cacheEntry);
+                request.addMarker("network-cache-written");
+            }
+
+            // Post the response back.
+            request.markDelivered();
+            mDelivery.postResponse(request, response);
+            request.notifyListenerResponseReceived(response);
+        } catch (VolleyError volleyError) {
+            volleyError.setNetworkTimeMs(SystemClock.elapsedRealtime() - startTimeMs);
+            parseAndDeliverNetworkError(request, volleyError);
+            request.notifyListenerResponseNotUsable();
+        } catch (Exception e) {
+            VolleyLog.e(e, "Unhandled exception %s", e.toString());
+            VolleyError volleyError = new VolleyError(e);
+            volleyError.setNetworkTimeMs(SystemClock.elapsedRealtime() - startTimeMs);
+            mDelivery.postError(request, volleyError);
+            request.notifyListenerResponseNotUsable();
         }
     }
 


### PR DESCRIPTION
Android has a long-standing known issue where local variables aren't
explicitly cleared even when they go out of scope, which can cause
their contents to leak. Clearing the variable explicitly is not a
sufficient fix because the clear is optimized out as it's not
observable. The best we can do is extract the contents of the loops in
question to helper methods and hope that they are complex enough that
code optimizers like Proguard won't inline them.

Should contain no functional changes otherwise.

Verified against provided sample app.

Fixes #114