### PR TITLE
Set project group and version.

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -17,8 +17,6 @@ apply plugin: 'maven-publish'
 
 def bintrayInfoFilePath = "$buildDir/outputs/bintray-descriptor.bintray-info.json"
 
-project.ext.version = '1.1.0-SNAPSHOT'
-
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from android.sourceSets.main.java.srcDirs
@@ -39,7 +37,7 @@ task bintrayInfoFile {
     doLast {
         println 'Creating bintray-info.json'
         String fileContent = new File("$rootDir/bintray-info-template.json").getText('UTF-8')
-        fileContent = fileContent.replace('$VERSION$', project.ext.version)
+        fileContent = fileContent.replace('$VERSION$', project.version)
         ((new File(bintrayInfoFilePath))).write(fileContent)
     }
 }
@@ -54,7 +52,7 @@ publishing {
         library(MavenPublication) {
             groupId 'com.android.volley'
             artifactId 'volley'
-            version project.ext.version
+            version project.version
             pom {
                 packaging 'aar'
             }

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ repositories {
     jcenter()
 }
 
+group = 'com.android.volley'
+version = '1.1.0-SNAPSHOT'
+
 android {
     compileSdkVersion 25
     buildToolsVersion = '25.0.2'


### PR DESCRIPTION
This is used by the Gradle Artifactory plugin when populating the
build info when publishing to OJO, which is in turn used to promote
OJO artifacts to Bintray proper.