### PR TITLE
Enable TLSv1.1 and TLSv1.2 by default on API 16-19.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -68,11 +68,19 @@ public class HurlStack extends BaseHttpStack {
 
     /**
      * @param urlRewriter Rewriter to use for request URLs
-     * @param sslSocketFactory SSL factory to use for HTTPS connections
+     * @param sslSocketFactory SSL factory to use for HTTPS connections. If none is provided, the
+     *                         system default will generally be used. However, support for TLSv1.1
+     *                         and 1.2 will be forcefully enabled on devices which support them even
+     *                         if they are not on by default. If this behavior is undesired, provide
+     *                         a custom SSLSocketFactory.
      */
     public HurlStack(UrlRewriter urlRewriter, SSLSocketFactory sslSocketFactory) {
         mUrlRewriter = urlRewriter;
-        mSslSocketFactory = sslSocketFactory;
+        if (sslSocketFactory != null) {
+            mSslSocketFactory = sslSocketFactory;
+        } else {
+            mSslSocketFactory = TlsEnabledSSLSocketFactory.newTlsEnabledSSLSocketFactoryIfNeeded();
+        }
     }
 
     @Override

--- a/src/main/java/com/android/volley/toolbox/InterceptingSSLSocketFactory.java
+++ b/src/main/java/com/android/volley/toolbox/InterceptingSSLSocketFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * {@link SSLSocketFactory} which defers to the given delegate and provides an intercept to inspect
+ * and alter created sockets.
+ */
+abstract class InterceptingSSLSocketFactory extends SSLSocketFactory {
+
+    private final SSLSocketFactory mDelegate;
+
+    InterceptingSSLSocketFactory(SSLSocketFactory delegate) {
+        mDelegate = delegate;
+    }
+
+    @Override
+    public final String[] getDefaultCipherSuites() {
+        return mDelegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public final String[] getSupportedCipherSuites() {
+        return mDelegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public final Socket createSocket(Socket s, String host, int port, boolean autoClose)
+            throws IOException {
+        Socket socket = mDelegate.createSocket(s, host, port, autoClose);
+        onSocketCreated(socket);
+        return socket;
+    }
+
+    @Override
+    public final Socket createSocket(String host, int port) throws IOException {
+        Socket socket = mDelegate.createSocket(host, port);
+        onSocketCreated(socket);
+        return socket;
+    }
+
+    @Override
+    public final Socket createSocket(InetAddress host, int port) throws IOException {
+        Socket socket = mDelegate.createSocket(host, port);
+        onSocketCreated(socket);
+        return socket;
+    }
+
+    @Override
+    public final Socket createSocket(
+            InetAddress address, int port, InetAddress localAddress, int localPort)
+            throws IOException {
+        Socket socket = mDelegate.createSocket(address, port, localAddress, localPort);
+        onSocketCreated(socket);
+        return socket;
+    }
+
+    @Override
+    public final Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+            throws IOException {
+        Socket socket = mDelegate.createSocket(host, port, localHost, localPort);
+        onSocketCreated(socket);
+        return socket;
+    }
+
+    /** Called whenever a new socket is created. */
+    protected abstract void onSocketCreated(Socket socket);
+}

--- a/src/main/java/com/android/volley/toolbox/TlsEnabledSSLSocketFactory.java
+++ b/src/main/java/com/android/volley/toolbox/TlsEnabledSSLSocketFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import android.os.Build;
+
+import com.android.volley.VolleyLog;
+
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * {@link SSLSocketFactory} which ensures TLSv1.1 and 1.2 are enabled where supported.
+ *
+ * <p>These protocols are supported on API 16+ devices but only enabled by default on API 20+
+ * devices. {@link #newTlsEnabledSSLSocketFactoryIfNeeded} will return a factory which attempts to
+ * enable these protocols on devices that fall in this range.
+ */
+class TlsEnabledSSLSocketFactory extends InterceptingSSLSocketFactory {
+
+    // VisibleForTesting
+    static final String TLS_1_1 = "TLSv1.1";
+    // VisibleForTesting
+    static final String TLS_1_2 = "TLSv1.2";
+
+    // Nullable
+    static SSLSocketFactory newTlsEnabledSSLSocketFactoryIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+                && Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT_WATCH) {
+            // No special factory needed - TLSv1.1 and 1.2 are unsupported prior to Jelly Bean and
+            // enabled by default on KitKat Watch+ devices per:
+            // https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+            return null;
+        }
+        SocketFactory socketFactory = SSLSocketFactory.getDefault();
+        if (!(socketFactory instanceof SSLSocketFactory)) {
+            VolleyLog.wtf(new IllegalStateException(),
+                    "SSLSocketFactory.getDefault() didn't return an SSLSocketFactory");
+            return null;
+        }
+        return new TlsEnabledSSLSocketFactory((SSLSocketFactory) socketFactory);
+    }
+
+    // VisibleForTesting
+    TlsEnabledSSLSocketFactory(SSLSocketFactory delegate) {
+        super(delegate);
+    }
+
+    @Override
+    protected void onSocketCreated(Socket socket) {
+        if (!(socket instanceof SSLSocket)) {
+            return;
+        }
+        SSLSocket sslSocket = (SSLSocket) socket;
+        boolean shouldEnableTls11 = shouldEnableProtocol(sslSocket, TLS_1_1);
+        boolean shouldEnableTls12 = shouldEnableProtocol(sslSocket, TLS_1_2);
+        if (!shouldEnableTls11 && !shouldEnableTls12) {
+            // Already enabled - unexpected, but no action is needed.
+            return;
+        }
+        // Add missing protocols to the list of enabled protocols.
+        List<String> augmentedProtocols =
+                new ArrayList<>(Arrays.asList(sslSocket.getEnabledProtocols()));
+        if (shouldEnableTls11) {
+            augmentedProtocols.add(TLS_1_1);
+        }
+        if (shouldEnableTls12) {
+            augmentedProtocols.add(TLS_1_2);
+        }
+        sslSocket.setEnabledProtocols(
+                augmentedProtocols.toArray(new String[augmentedProtocols.size()]));
+    }
+
+    private static boolean shouldEnableProtocol(SSLSocket sslSocket, String protocol) {
+        return !linearSearch(sslSocket.getEnabledProtocols(), protocol)
+                && linearSearch(sslSocket.getSupportedProtocols(), protocol);
+    }
+
+    private static <T> boolean linearSearch(T[] array, T item) {
+        for (T arrayItem : array) {
+            if (item.equals(arrayItem)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/android/volley/toolbox/TlsEnabledSSLSocketFactoryTest.java
+++ b/src/test/java/com/android/volley/toolbox/TlsEnabledSSLSocketFactoryTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+public class TlsEnabledSSLSocketFactoryTest {
+    private static final String TLS_1 = "TLSv1";
+    private static final String DUMMY_PROTOCOL = "Dummy";
+
+    @Mock
+    private SSLSocketFactory mMockSystemSocketFactory;
+    @Mock
+    private SSLSocket mMockSocket;
+
+    private TlsEnabledSSLSocketFactory mTlsSocketFactory;
+
+    @Before
+    public void setUp() throws IOException {
+        MockitoAnnotations.initMocks(this);
+        mTlsSocketFactory = new TlsEnabledSSLSocketFactory(mMockSystemSocketFactory);
+        when(mMockSystemSocketFactory.createSocket(anyString(), anyInt())).thenReturn(mMockSocket);
+    }
+
+    @Test
+    public void bothDisabled() throws IOException {
+        when(mMockSocket.getSupportedProtocols()).thenReturn(
+                new String[] {
+                        TLS_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_2,
+                        DUMMY_PROTOCOL });
+        when(mMockSocket.getEnabledProtocols()).thenReturn(new String[] { });
+
+        mTlsSocketFactory.createSocket("dummy", 12345);
+
+        verify(mMockSocket).setEnabledProtocols(aryEq(new String[] {
+                TlsEnabledSSLSocketFactory.TLS_1_1,
+                TlsEnabledSSLSocketFactory.TLS_1_2 }));
+    }
+
+    @Test
+    public void bothDisabled_hasOtherEnabledProtocols() throws IOException {
+        when(mMockSocket.getSupportedProtocols()).thenReturn(
+                new String[] {
+                        TLS_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_2,
+                        DUMMY_PROTOCOL });
+        when(mMockSocket.getEnabledProtocols()).thenReturn(new String[] { TLS_1 });
+
+        mTlsSocketFactory.createSocket("dummy", 12345);
+
+        verify(mMockSocket).setEnabledProtocols(aryEq(new String[] {
+                TLS_1,
+                TlsEnabledSSLSocketFactory.TLS_1_1,
+                TlsEnabledSSLSocketFactory.TLS_1_2 }));
+    }
+
+    @Test
+    public void needsTls11() throws IOException {
+        when(mMockSocket.getSupportedProtocols()).thenReturn(
+                new String[] {
+                        TlsEnabledSSLSocketFactory.TLS_1_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_2 });
+        when(mMockSocket.getEnabledProtocols()).thenReturn(
+                new String[] { TlsEnabledSSLSocketFactory.TLS_1_2 });
+
+        mTlsSocketFactory.createSocket("dummy", 12345);
+
+        verify(mMockSocket).setEnabledProtocols(aryEq(new String[] {
+                TlsEnabledSSLSocketFactory.TLS_1_2,
+                TlsEnabledSSLSocketFactory.TLS_1_1 }));
+    }
+
+    @Test
+    public void needsTls12() throws IOException {
+        when(mMockSocket.getSupportedProtocols()).thenReturn(
+                new String[] {
+                        TlsEnabledSSLSocketFactory.TLS_1_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_2 });
+        when(mMockSocket.getEnabledProtocols()).thenReturn(
+                new String[] { TlsEnabledSSLSocketFactory.TLS_1_1 });
+
+        mTlsSocketFactory.createSocket("dummy", 12345);
+
+        verify(mMockSocket).setEnabledProtocols(aryEq(new String[] {
+                TlsEnabledSSLSocketFactory.TLS_1_1,
+                TlsEnabledSSLSocketFactory.TLS_1_2 }));
+    }
+
+    @Test
+    public void alreadyHasBothEnabled() throws IOException {
+        when(mMockSocket.getSupportedProtocols()).thenReturn(
+                new String[] {
+                        TlsEnabledSSLSocketFactory.TLS_1_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_2 });
+        when(mMockSocket.getEnabledProtocols()).thenReturn(
+                new String[] {
+                        TlsEnabledSSLSocketFactory.TLS_1_1,
+                        TlsEnabledSSLSocketFactory.TLS_1_2 });
+
+        mTlsSocketFactory.createSocket("dummy", 12345);
+
+        verify(mMockSocket, never()).setEnabledProtocols(ArgumentMatchers.<String[]>any());
+    }
+}


### PR DESCRIPTION
Per:

https://developer.android.com/reference/javax/net/ssl/SSLSocket.html

These protocols are supported on API 16+, but not enabled by default
until API 20+. This has led to frequent bug reports on such devices
for servers which only support TLSv1.2. As such, if no custom
SSLSocketFactory is provided to HurlStack, we can use our own which
adds these new protocols to whatever is already supported by default.

This should be low risk - we're only enabling new protocols without
disabling old ones, and if there were issues with a server's TLSv1.2
implementation then they'd likely be visible to other clients. As
such, the benefits of enabling these protocols by default should
outweigh the risks of regression for existing Volley users, who would
likely want to resolve the server-side issue anyway, but could still
work around the issue by providing their own SSLSocketFactory
implementation.

Fixes #77