### PR TITLE
Add a concept of public APIs to Volley.

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -23,6 +23,10 @@ task sourcesJar(type: Jar) {
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    // Exclude classes with "Internal" in the name from generated Javadoc, as these are obfuscated
+    // and not part of the Volley API.
+    exclude 'com/android/volley/internal/**'
+
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -45,8 +49,9 @@ publishing {
                 packaging 'aar'
             }
 
-            // Release AAR, Sources, and JavaDoc
+            // Release AAR, sources, javadoc, and proguard mapping
             artifact "$buildDir/outputs/aar/volley-release.aar"
+            artifact "$buildDir/outputs/mapping/release/mapping.txt"
             artifact sourcesJar
             artifact javadocJar
         }

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,9 @@
+-keepparameternames
+-renamesourcefileattribute SourceFile
+-keepattributes Exceptions,InnerClasses,Signature,Deprecated,SourceFile,LineNumberTable,*Annotation*,EnclosingMethod
+
+# Keep all public/protected classes/methods/fields, except for classes in the internal package.
+# These will be obfuscated and should not be used externally.
+-keep public class !com.android.volley.internal.**,** {
+    public protected *;
+}

--- a/rules.gradle
+++ b/rules.gradle
@@ -10,6 +10,14 @@ android {
     targetCompatibility JavaVersion.VERSION_1_7
   }
 
+  // Enable obfuscation of private APIs in release builds.
+  buildTypes {
+    release {
+      minifyEnabled true
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+    }
+  }
+
   defaultConfig {
     consumerProguardFiles 'consumer-proguard-rules.pro'
   }
@@ -19,6 +27,8 @@ android {
 if (configurations.findByName("testCompile")) {
   dependencies {
     testCompile "junit:junit:4.12"
+    testCompile "com.google.guava:guava:24.1-android"
+    testCompile "com.google.truth:truth:0.40"
     testCompile "org.hamcrest:hamcrest-library:1.3"
     testCompile "org.mockito:mockito-core:2.2.29"
     testCompile "org.robolectric:robolectric:3.0"

--- a/src/main/java/com/android/volley/NetworkResponse.java
+++ b/src/main/java/com/android/volley/NetworkResponse.java
@@ -16,12 +16,12 @@
 
 package com.android.volley;
 
+import com.android.volley.internal.HeaderConversions;
+
 import java.net.HttpURLConnection;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Data and headers returned from {@link Network#performRequest(Request)}.
@@ -42,7 +42,8 @@ public class NetworkResponse {
     @Deprecated
     public NetworkResponse(int statusCode, byte[] data, Map<String, String> headers,
             boolean notModified, long networkTimeMs) {
-        this(statusCode, data, headers, toAllHeaderList(headers), notModified, networkTimeMs);
+        this(statusCode, data, headers, HeaderConversions.toAllHeaderList(headers), notModified,
+                networkTimeMs);
     }
 
     /**
@@ -55,7 +56,8 @@ public class NetworkResponse {
      */
     public NetworkResponse(int statusCode, byte[] data, boolean notModified, long networkTimeMs,
             List<Header> allHeaders) {
-        this(statusCode, data, toHeaderMap(allHeaders), allHeaders, notModified, networkTimeMs);
+        this(statusCode, data, HeaderConversions.toHeaderMap(allHeaders), allHeaders, notModified,
+                networkTimeMs);
     }
 
     /**
@@ -134,34 +136,5 @@ public class NetworkResponse {
 
     /** Network roundtrip time in milliseconds. */
     public final long networkTimeMs;
-
-    private static Map<String, String> toHeaderMap(List<Header> allHeaders) {
-        if (allHeaders == null) {
-            return null;
-        }
-        if (allHeaders.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        // Later elements in the list take precedence.
-        for (Header header : allHeaders) {
-            headers.put(header.getName(), header.getValue());
-        }
-        return headers;
-    }
-
-    private static List<Header> toAllHeaderList(Map<String, String> headers) {
-        if (headers == null) {
-            return null;
-        }
-        if (headers.isEmpty()) {
-            return Collections.emptyList();
-        }
-        List<Header> allHeaders = new ArrayList<>(headers.size());
-        for (Map.Entry<String, String> header : headers.entrySet()) {
-            allHeaders.add(new Header(header.getKey(), header.getValue()));
-        }
-        return allHeaders;
-    }
 }
 

--- a/src/main/java/com/android/volley/internal/HeaderConversions.java
+++ b/src/main/java/com/android/volley/internal/HeaderConversions.java
@@ -1,0 +1,34 @@
+package com.android.volley.internal;
+
+import com.android.volley.Header;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Utilities to convert between different header containers.
+ *
+ * <p>This class is internal to Volley and should not be used externally.
+ */
+public final class HeaderConversions {
+    private HeaderConversions() {}
+
+    public static Map<String, String> toHeaderMap(List<Header> allHeaders) {
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        // Later elements in the list take precedence.
+        for (Header header : allHeaders) {
+            headers.put(header.getName(), header.getValue());
+        }
+        return headers;
+    }
+
+    public static List<Header> toAllHeaderList(Map<String, String> headers) {
+        List<Header> allHeaders = new ArrayList<>(headers.size());
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            allHeaders.add(new Header(header.getKey(), header.getValue()));
+        }
+        return allHeaders;
+    }
+}

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -21,6 +21,7 @@ import android.text.TextUtils;
 
 import com.android.volley.Cache;
 import com.android.volley.Header;
+import com.android.volley.internal.HeaderConversions;
 import com.android.volley.VolleyLog;
 
 import java.io.BufferedInputStream;
@@ -414,7 +415,7 @@ public class DiskBasedCache implements Cache {
             }
 
             // Legacy fallback - copy headers from the map.
-            return HttpHeaderParser.toAllHeaderList(entry.responseHeaders);
+            return HeaderConversions.toAllHeaderList(entry.responseHeaders);
         }
 
         /**
@@ -450,7 +451,7 @@ public class DiskBasedCache implements Cache {
             e.lastModified = lastModified;
             e.ttl = ttl;
             e.softTtl = softTtl;
-            e.responseHeaders = HttpHeaderParser.toHeaderMap(allResponseHeaders);
+            e.responseHeaders = HeaderConversions.toHeaderMap(allResponseHeaders);
             e.allResponseHeaders = Collections.unmodifiableList(allResponseHeaders);
             return e;
         }

--- a/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
@@ -17,19 +17,15 @@
 package com.android.volley.toolbox;
 
 import com.android.volley.Cache;
-import com.android.volley.Header;
 import com.android.volley.NetworkResponse;
 import com.android.volley.VolleyLog;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.TreeMap;
 
 /**
  * Utility methods for parsing HTTP headers.
@@ -190,27 +186,5 @@ public class HttpHeaderParser {
      */
     public static String parseCharset(Map<String, String> headers) {
         return parseCharset(headers, DEFAULT_CONTENT_CHARSET);
-    }
-
-    // Note - these are copied from NetworkResponse to avoid making them public (as needed to access
-    // them from the .toolbox package), which would mean they'd become part of the Volley API.
-    // TODO: Consider obfuscating official releases so we can share utility methods between Volley
-    // and Toolbox without making them public APIs.
-
-    static Map<String, String> toHeaderMap(List<Header> allHeaders) {
-        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        // Later elements in the list take precedence.
-        for (Header header : allHeaders) {
-            headers.put(header.getName(), header.getValue());
-        }
-        return headers;
-    }
-
-    static List<Header> toAllHeaderList(Map<String, String> headers) {
-        List<Header> allHeaders = new ArrayList<>(headers.size());
-        for (Map.Entry<String, String> header : headers.entrySet()) {
-            allHeaders.add(new Header(header.getKey(), header.getValue()));
-        }
-        return allHeaders;
     }
 }

--- a/src/test/java/com/android/volley/VolleyApisTest.java
+++ b/src/test/java/com/android/volley/VolleyApisTest.java
@@ -1,0 +1,119 @@
+package com.android.volley;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import com.google.common.reflect.ClassPath;
+import com.google.common.truth.Truth;
+
+import org.junit.Test;
+import org.robolectric.util.Strings;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test for Volley's public API signatures.
+ */
+public class VolleyApisTest {
+    private static final List<String> TEST_CLASS_PREFIX_BLACKLIST = ImmutableList.of(
+            "com.android.volley.mock",
+            "com.android.volley.utils.CacheTestUtils",
+            "com.android.volley.utils.ImmediateResponseDelivery");
+
+    @Test
+    public void noUnexpectedApis() throws Exception {
+        String apiText = Resources.toString(Resources.getResource("api.txt"), Charsets.UTF_8);
+        List<String> expectedApis = Splitter.on("\n").splitToList(apiText.trim());
+
+        List<String> actualApis = new ArrayList<>();
+        ClassPath classPath = ClassPath.from(ClassLoader.getSystemClassLoader());
+        for (ClassPath.ClassInfo classInfo :
+                classPath.getTopLevelClassesRecursive("com.android.volley")) {
+            Class<?> clazz = classInfo.load();
+            processClass(clazz, actualApis);
+        }
+        Collections.sort(actualApis);
+        Truth.assertWithMessage("The API signature of Volley has changed. If this is expected, " +
+                "update src/test/resources/api.txt with the new APIs.")
+                .that(actualApis)
+                .containsExactlyElementsIn(expectedApis)
+                .inOrder();
+    }
+
+    private void processClass(Class<?> clazz, List<String> apis) {
+        if (isTestOrInternalClass(clazz.getName())) {
+            return;
+        }
+        if (!isVisible(clazz.getModifiers())) {
+            return;
+        }
+        apis.add(clazz.getName() + ": class " + getSignature(clazz));
+        for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+            if (!isVisible(constructor.getModifiers())) {
+                continue;
+            }
+            apis.add(clazz.getName() + ": ctor " + constructor.toGenericString());
+        }
+        for (Field field : clazz.getDeclaredFields()) {
+            if (!isVisible(field.getModifiers())) {
+                continue;
+            }
+            // TODO: Consider also locking down field values.
+            apis.add(clazz.getName() + ": field " + field.toGenericString());
+        }
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (!isVisible(method.getModifiers())) {
+                continue;
+            }
+            apis.add(clazz.getName() + ": method " + method.toGenericString());
+        }
+        for (Class<?> innerClazz : clazz.getDeclaredClasses()) {
+            processClass(innerClazz, apis);
+        }
+    }
+
+    private boolean isTestOrInternalClass(String className) {
+        if (className.startsWith("com.android.volley.internal")) {
+            // Classes in this package are obfuscated and thus not easily accessible externally.
+            // We do not consider them part of the public API.
+            return true;
+        }
+        // Best-effort attempt at excluding everything in src/test/java, since it's all part of the
+        // same class path.
+        if (className.endsWith("Test")) {
+            return true;
+        }
+        for (String prefix : TEST_CLASS_PREFIX_BLACKLIST) {
+            if (className.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isVisible(int modifiers) {
+        return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers);
+    }
+
+    private String getSignature(Class<?> clazz) {
+        StringBuilder signature = new StringBuilder(Modifier.toString(clazz.getModifiers()));
+        if (clazz.getSuperclass() != null &&
+                !Strings.equals("java.lang.Object", clazz.getSuperclass().getName())) {
+            signature.append(", extends ").append(clazz.getSuperclass().getName());
+        }
+        if (clazz.getGenericInterfaces().length > 0) {
+            signature.append(", implements");
+            for (Class<?> iface : clazz.getInterfaces()) {
+                signature.append(" ").append(iface.getName());
+            }
+        }
+        return signature.toString();
+    }
+}

--- a/src/test/java/com/android/volley/toolbox/HttpHeaderParserTest.java
+++ b/src/test/java/com/android/volley/toolbox/HttpHeaderParserTest.java
@@ -18,6 +18,7 @@ package com.android.volley.toolbox;
 
 import com.android.volley.Cache;
 import com.android.volley.Header;
+import com.android.volley.internal.HeaderConversions;
 import com.android.volley.NetworkResponse;
 
 import org.junit.Before;
@@ -287,6 +288,6 @@ public class HttpHeaderParserTest {
         assertEqualsWithin(now + ONE_DAY_MILLIS, entry.ttl, ONE_MINUTE_MILLIS);
         assertEquals(entry.softTtl, entry.ttl);
         assertEquals("ISO-8859-1",
-                HttpHeaderParser.parseCharset(HttpHeaderParser.toHeaderMap(headers)));
+                HttpHeaderParser.parseCharset(HeaderConversions.toHeaderMap(headers)));
     }
 }

--- a/src/test/resources/api.txt
+++ b/src/test/resources/api.txt
@@ -1,0 +1,396 @@
+com.android.volley.AuthFailureError: class public, extends com.android.volley.VolleyError
+com.android.volley.AuthFailureError: ctor public com.android.volley.AuthFailureError()
+com.android.volley.AuthFailureError: ctor public com.android.volley.AuthFailureError(android.content.Intent)
+com.android.volley.AuthFailureError: ctor public com.android.volley.AuthFailureError(com.android.volley.NetworkResponse)
+com.android.volley.AuthFailureError: ctor public com.android.volley.AuthFailureError(java.lang.String)
+com.android.volley.AuthFailureError: ctor public com.android.volley.AuthFailureError(java.lang.String,java.lang.Exception)
+com.android.volley.AuthFailureError: method public android.content.Intent com.android.volley.AuthFailureError.getResolutionIntent()
+com.android.volley.AuthFailureError: method public java.lang.String com.android.volley.AuthFailureError.getMessage()
+com.android.volley.BuildConfig: class public final
+com.android.volley.BuildConfig: ctor public com.android.volley.BuildConfig()
+com.android.volley.BuildConfig: field public static final boolean com.android.volley.BuildConfig.DEBUG
+com.android.volley.BuildConfig: field public static final int com.android.volley.BuildConfig.VERSION_CODE
+com.android.volley.BuildConfig: field public static final java.lang.String com.android.volley.BuildConfig.APPLICATION_ID
+com.android.volley.BuildConfig: field public static final java.lang.String com.android.volley.BuildConfig.BUILD_TYPE
+com.android.volley.BuildConfig: field public static final java.lang.String com.android.volley.BuildConfig.FLAVOR
+com.android.volley.BuildConfig: field public static final java.lang.String com.android.volley.BuildConfig.VERSION_NAME
+com.android.volley.Cache$Entry: class public static
+com.android.volley.Cache$Entry: ctor public com.android.volley.Cache$Entry()
+com.android.volley.Cache$Entry: field public byte[] com.android.volley.Cache$Entry.data
+com.android.volley.Cache$Entry: field public java.lang.String com.android.volley.Cache$Entry.etag
+com.android.volley.Cache$Entry: field public java.util.List<com.android.volley.Header> com.android.volley.Cache$Entry.allResponseHeaders
+com.android.volley.Cache$Entry: field public java.util.Map<java.lang.String, java.lang.String> com.android.volley.Cache$Entry.responseHeaders
+com.android.volley.Cache$Entry: field public long com.android.volley.Cache$Entry.lastModified
+com.android.volley.Cache$Entry: field public long com.android.volley.Cache$Entry.serverDate
+com.android.volley.Cache$Entry: field public long com.android.volley.Cache$Entry.softTtl
+com.android.volley.Cache$Entry: field public long com.android.volley.Cache$Entry.ttl
+com.android.volley.Cache$Entry: method public boolean com.android.volley.Cache$Entry.isExpired()
+com.android.volley.Cache$Entry: method public boolean com.android.volley.Cache$Entry.refreshNeeded()
+com.android.volley.Cache: class public abstract interface
+com.android.volley.Cache: method public abstract com.android.volley.Cache$Entry com.android.volley.Cache.get(java.lang.String)
+com.android.volley.Cache: method public abstract void com.android.volley.Cache.clear()
+com.android.volley.Cache: method public abstract void com.android.volley.Cache.initialize()
+com.android.volley.Cache: method public abstract void com.android.volley.Cache.invalidate(java.lang.String,boolean)
+com.android.volley.Cache: method public abstract void com.android.volley.Cache.put(java.lang.String,com.android.volley.Cache$Entry)
+com.android.volley.Cache: method public abstract void com.android.volley.Cache.remove(java.lang.String)
+com.android.volley.CacheDispatcher: class public, extends java.lang.Thread
+com.android.volley.CacheDispatcher: ctor public com.android.volley.CacheDispatcher(java.util.concurrent.BlockingQueue<com.android.volley.Request<?>>,java.util.concurrent.BlockingQueue<com.android.volley.Request<?>>,com.android.volley.Cache,com.android.volley.ResponseDelivery)
+com.android.volley.CacheDispatcher: method public void com.android.volley.CacheDispatcher.quit()
+com.android.volley.CacheDispatcher: method public void com.android.volley.CacheDispatcher.run()
+com.android.volley.ClientError: class public, extends com.android.volley.ServerError
+com.android.volley.ClientError: ctor public com.android.volley.ClientError()
+com.android.volley.ClientError: ctor public com.android.volley.ClientError(com.android.volley.NetworkResponse)
+com.android.volley.DefaultRetryPolicy: class public, implements com.android.volley.RetryPolicy
+com.android.volley.DefaultRetryPolicy: ctor public com.android.volley.DefaultRetryPolicy()
+com.android.volley.DefaultRetryPolicy: ctor public com.android.volley.DefaultRetryPolicy(int,int,float)
+com.android.volley.DefaultRetryPolicy: field public static final float com.android.volley.DefaultRetryPolicy.DEFAULT_BACKOFF_MULT
+com.android.volley.DefaultRetryPolicy: field public static final int com.android.volley.DefaultRetryPolicy.DEFAULT_MAX_RETRIES
+com.android.volley.DefaultRetryPolicy: field public static final int com.android.volley.DefaultRetryPolicy.DEFAULT_TIMEOUT_MS
+com.android.volley.DefaultRetryPolicy: method protected boolean com.android.volley.DefaultRetryPolicy.hasAttemptRemaining()
+com.android.volley.DefaultRetryPolicy: method public float com.android.volley.DefaultRetryPolicy.getBackoffMultiplier()
+com.android.volley.DefaultRetryPolicy: method public int com.android.volley.DefaultRetryPolicy.getCurrentRetryCount()
+com.android.volley.DefaultRetryPolicy: method public int com.android.volley.DefaultRetryPolicy.getCurrentTimeout()
+com.android.volley.DefaultRetryPolicy: method public void com.android.volley.DefaultRetryPolicy.retry(com.android.volley.VolleyError) throws com.android.volley.VolleyError
+com.android.volley.ExecutorDelivery: class public, implements com.android.volley.ResponseDelivery
+com.android.volley.ExecutorDelivery: ctor public com.android.volley.ExecutorDelivery(android.os.Handler)
+com.android.volley.ExecutorDelivery: ctor public com.android.volley.ExecutorDelivery(java.util.concurrent.Executor)
+com.android.volley.ExecutorDelivery: method public void com.android.volley.ExecutorDelivery.postError(com.android.volley.Request<?>,com.android.volley.VolleyError)
+com.android.volley.ExecutorDelivery: method public void com.android.volley.ExecutorDelivery.postResponse(com.android.volley.Request<?>,com.android.volley.Response<?>)
+com.android.volley.ExecutorDelivery: method public void com.android.volley.ExecutorDelivery.postResponse(com.android.volley.Request<?>,com.android.volley.Response<?>,java.lang.Runnable)
+com.android.volley.Header: class public final
+com.android.volley.Header: ctor public com.android.volley.Header(java.lang.String,java.lang.String)
+com.android.volley.Header: method public boolean com.android.volley.Header.equals(java.lang.Object)
+com.android.volley.Header: method public final java.lang.String com.android.volley.Header.getName()
+com.android.volley.Header: method public final java.lang.String com.android.volley.Header.getValue()
+com.android.volley.Header: method public int com.android.volley.Header.hashCode()
+com.android.volley.Header: method public java.lang.String com.android.volley.Header.toString()
+com.android.volley.Network: class public abstract interface
+com.android.volley.Network: method public abstract com.android.volley.NetworkResponse com.android.volley.Network.performRequest(com.android.volley.Request<?>) throws com.android.volley.VolleyError
+com.android.volley.NetworkDispatcher: class public, extends java.lang.Thread
+com.android.volley.NetworkDispatcher: ctor public com.android.volley.NetworkDispatcher(java.util.concurrent.BlockingQueue<com.android.volley.Request<?>>,com.android.volley.Network,com.android.volley.Cache,com.android.volley.ResponseDelivery)
+com.android.volley.NetworkDispatcher: method public void com.android.volley.NetworkDispatcher.quit()
+com.android.volley.NetworkDispatcher: method public void com.android.volley.NetworkDispatcher.run()
+com.android.volley.NetworkError: class public, extends com.android.volley.VolleyError
+com.android.volley.NetworkError: ctor public com.android.volley.NetworkError()
+com.android.volley.NetworkError: ctor public com.android.volley.NetworkError(com.android.volley.NetworkResponse)
+com.android.volley.NetworkError: ctor public com.android.volley.NetworkError(java.lang.Throwable)
+com.android.volley.NetworkResponse: class public
+com.android.volley.NetworkResponse: ctor public com.android.volley.NetworkResponse(byte[])
+com.android.volley.NetworkResponse: ctor public com.android.volley.NetworkResponse(byte[],java.util.Map<java.lang.String, java.lang.String>)
+com.android.volley.NetworkResponse: ctor public com.android.volley.NetworkResponse(int,byte[],boolean,long,java.util.List<com.android.volley.Header>)
+com.android.volley.NetworkResponse: ctor public com.android.volley.NetworkResponse(int,byte[],java.util.Map<java.lang.String, java.lang.String>,boolean)
+com.android.volley.NetworkResponse: ctor public com.android.volley.NetworkResponse(int,byte[],java.util.Map<java.lang.String, java.lang.String>,boolean,long)
+com.android.volley.NetworkResponse: field public final boolean com.android.volley.NetworkResponse.notModified
+com.android.volley.NetworkResponse: field public final byte[] com.android.volley.NetworkResponse.data
+com.android.volley.NetworkResponse: field public final int com.android.volley.NetworkResponse.statusCode
+com.android.volley.NetworkResponse: field public final java.util.List<com.android.volley.Header> com.android.volley.NetworkResponse.allHeaders
+com.android.volley.NetworkResponse: field public final java.util.Map<java.lang.String, java.lang.String> com.android.volley.NetworkResponse.headers
+com.android.volley.NetworkResponse: field public final long com.android.volley.NetworkResponse.networkTimeMs
+com.android.volley.NoConnectionError: class public, extends com.android.volley.NetworkError
+com.android.volley.NoConnectionError: ctor public com.android.volley.NoConnectionError()
+com.android.volley.NoConnectionError: ctor public com.android.volley.NoConnectionError(java.lang.Throwable)
+com.android.volley.ParseError: class public, extends com.android.volley.VolleyError
+com.android.volley.ParseError: ctor public com.android.volley.ParseError()
+com.android.volley.ParseError: ctor public com.android.volley.ParseError(com.android.volley.NetworkResponse)
+com.android.volley.ParseError: ctor public com.android.volley.ParseError(java.lang.Throwable)
+com.android.volley.Request$Method: class public abstract static interface
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.DELETE
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.DEPRECATED_GET_OR_POST
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.GET
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.HEAD
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.OPTIONS
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.PATCH
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.POST
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.PUT
+com.android.volley.Request$Method: field public static final int com.android.volley.Request$Method.TRACE
+com.android.volley.Request$Priority: class public static final, extends java.lang.Enum
+com.android.volley.Request$Priority: field public static final com.android.volley.Request$Priority com.android.volley.Request$Priority.HIGH
+com.android.volley.Request$Priority: field public static final com.android.volley.Request$Priority com.android.volley.Request$Priority.IMMEDIATE
+com.android.volley.Request$Priority: field public static final com.android.volley.Request$Priority com.android.volley.Request$Priority.LOW
+com.android.volley.Request$Priority: field public static final com.android.volley.Request$Priority com.android.volley.Request$Priority.NORMAL
+com.android.volley.Request$Priority: method public static com.android.volley.Request$Priority com.android.volley.Request$Priority.valueOf(java.lang.String)
+com.android.volley.Request$Priority: method public static com.android.volley.Request$Priority[] com.android.volley.Request$Priority.values()
+com.android.volley.Request: class public abstract, implements java.lang.Comparable
+com.android.volley.Request: ctor public com.android.volley.Request(int,java.lang.String,com.android.volley.Response$ErrorListener)
+com.android.volley.Request: ctor public com.android.volley.Request(java.lang.String,com.android.volley.Response$ErrorListener)
+com.android.volley.Request: method protected abstract com.android.volley.Response<T> com.android.volley.Request.parseNetworkResponse(com.android.volley.NetworkResponse)
+com.android.volley.Request: method protected abstract void com.android.volley.Request.deliverResponse(T)
+com.android.volley.Request: method protected com.android.volley.VolleyError com.android.volley.Request.parseNetworkError(com.android.volley.VolleyError)
+com.android.volley.Request: method protected java.lang.String com.android.volley.Request.getParamsEncoding()
+com.android.volley.Request: method protected java.lang.String com.android.volley.Request.getPostParamsEncoding()
+com.android.volley.Request: method protected java.util.Map<java.lang.String, java.lang.String> com.android.volley.Request.getParams() throws com.android.volley.AuthFailureError
+com.android.volley.Request: method protected java.util.Map<java.lang.String, java.lang.String> com.android.volley.Request.getPostParams() throws com.android.volley.AuthFailureError
+com.android.volley.Request: method public boolean com.android.volley.Request.hasHadResponseDelivered()
+com.android.volley.Request: method public boolean com.android.volley.Request.isCanceled()
+com.android.volley.Request: method public byte[] com.android.volley.Request.getBody() throws com.android.volley.AuthFailureError
+com.android.volley.Request: method public byte[] com.android.volley.Request.getPostBody() throws com.android.volley.AuthFailureError
+com.android.volley.Request: method public com.android.volley.Cache$Entry com.android.volley.Request.getCacheEntry()
+com.android.volley.Request: method public com.android.volley.Request$Priority com.android.volley.Request.getPriority()
+com.android.volley.Request: method public com.android.volley.Request<?> com.android.volley.Request.setCacheEntry(com.android.volley.Cache$Entry)
+com.android.volley.Request: method public com.android.volley.Request<?> com.android.volley.Request.setRequestQueue(com.android.volley.RequestQueue)
+com.android.volley.Request: method public com.android.volley.Request<?> com.android.volley.Request.setRetryPolicy(com.android.volley.RetryPolicy)
+com.android.volley.Request: method public com.android.volley.Request<?> com.android.volley.Request.setTag(java.lang.Object)
+com.android.volley.Request: method public com.android.volley.Response$ErrorListener com.android.volley.Request.getErrorListener()
+com.android.volley.Request: method public com.android.volley.RetryPolicy com.android.volley.Request.getRetryPolicy()
+com.android.volley.Request: method public final boolean com.android.volley.Request.shouldCache()
+com.android.volley.Request: method public final boolean com.android.volley.Request.shouldRetryServerErrors()
+com.android.volley.Request: method public final com.android.volley.Request<?> com.android.volley.Request.setSequence(int)
+com.android.volley.Request: method public final com.android.volley.Request<?> com.android.volley.Request.setShouldCache(boolean)
+com.android.volley.Request: method public final com.android.volley.Request<?> com.android.volley.Request.setShouldRetryServerErrors(boolean)
+com.android.volley.Request: method public final int com.android.volley.Request.getSequence()
+com.android.volley.Request: method public final int com.android.volley.Request.getTimeoutMs()
+com.android.volley.Request: method public int com.android.volley.Request.compareTo(com.android.volley.Request<T>)
+com.android.volley.Request: method public int com.android.volley.Request.compareTo(java.lang.Object)
+com.android.volley.Request: method public int com.android.volley.Request.getMethod()
+com.android.volley.Request: method public int com.android.volley.Request.getTrafficStatsTag()
+com.android.volley.Request: method public java.lang.Object com.android.volley.Request.getTag()
+com.android.volley.Request: method public java.lang.String com.android.volley.Request.getBodyContentType()
+com.android.volley.Request: method public java.lang.String com.android.volley.Request.getCacheKey()
+com.android.volley.Request: method public java.lang.String com.android.volley.Request.getPostBodyContentType()
+com.android.volley.Request: method public java.lang.String com.android.volley.Request.getUrl()
+com.android.volley.Request: method public java.lang.String com.android.volley.Request.toString()
+com.android.volley.Request: method public java.util.Map<java.lang.String, java.lang.String> com.android.volley.Request.getHeaders() throws com.android.volley.AuthFailureError
+com.android.volley.Request: method public void com.android.volley.Request.addMarker(java.lang.String)
+com.android.volley.Request: method public void com.android.volley.Request.cancel()
+com.android.volley.Request: method public void com.android.volley.Request.deliverError(com.android.volley.VolleyError)
+com.android.volley.Request: method public void com.android.volley.Request.markDelivered()
+com.android.volley.RequestQueue$RequestFilter: class public abstract static interface
+com.android.volley.RequestQueue$RequestFilter: method public abstract boolean com.android.volley.RequestQueue$RequestFilter.apply(com.android.volley.Request<?>)
+com.android.volley.RequestQueue$RequestFinishedListener: class public abstract static interface
+com.android.volley.RequestQueue$RequestFinishedListener: method public abstract void com.android.volley.RequestQueue$RequestFinishedListener.onRequestFinished(com.android.volley.Request<T>)
+com.android.volley.RequestQueue: class public
+com.android.volley.RequestQueue: ctor public com.android.volley.RequestQueue(com.android.volley.Cache,com.android.volley.Network)
+com.android.volley.RequestQueue: ctor public com.android.volley.RequestQueue(com.android.volley.Cache,com.android.volley.Network,int)
+com.android.volley.RequestQueue: ctor public com.android.volley.RequestQueue(com.android.volley.Cache,com.android.volley.Network,int,com.android.volley.ResponseDelivery)
+com.android.volley.RequestQueue: method public <T> com.android.volley.Request<T> com.android.volley.RequestQueue.add(com.android.volley.Request<T>)
+com.android.volley.RequestQueue: method public <T> void com.android.volley.RequestQueue.addRequestFinishedListener(com.android.volley.RequestQueue.com.android.volley.RequestQueue$RequestFinishedListener<T>)
+com.android.volley.RequestQueue: method public <T> void com.android.volley.RequestQueue.removeRequestFinishedListener(com.android.volley.RequestQueue.com.android.volley.RequestQueue$RequestFinishedListener<T>)
+com.android.volley.RequestQueue: method public com.android.volley.Cache com.android.volley.RequestQueue.getCache()
+com.android.volley.RequestQueue: method public int com.android.volley.RequestQueue.getSequenceNumber()
+com.android.volley.RequestQueue: method public void com.android.volley.RequestQueue.cancelAll(com.android.volley.RequestQueue$RequestFilter)
+com.android.volley.RequestQueue: method public void com.android.volley.RequestQueue.cancelAll(java.lang.Object)
+com.android.volley.RequestQueue: method public void com.android.volley.RequestQueue.start()
+com.android.volley.RequestQueue: method public void com.android.volley.RequestQueue.stop()
+com.android.volley.Response$ErrorListener: class public abstract static interface
+com.android.volley.Response$ErrorListener: method public abstract void com.android.volley.Response$ErrorListener.onErrorResponse(com.android.volley.VolleyError)
+com.android.volley.Response$Listener: class public abstract static interface
+com.android.volley.Response$Listener: method public abstract void com.android.volley.Response$Listener.onResponse(T)
+com.android.volley.Response: class public
+com.android.volley.Response: field public boolean com.android.volley.Response.intermediate
+com.android.volley.Response: field public final T com.android.volley.Response.result
+com.android.volley.Response: field public final com.android.volley.Cache$Entry com.android.volley.Response.cacheEntry
+com.android.volley.Response: field public final com.android.volley.VolleyError com.android.volley.Response.error
+com.android.volley.Response: method public boolean com.android.volley.Response.isSuccess()
+com.android.volley.Response: method public static <T> com.android.volley.Response<T> com.android.volley.Response.error(com.android.volley.VolleyError)
+com.android.volley.Response: method public static <T> com.android.volley.Response<T> com.android.volley.Response.success(T,com.android.volley.Cache$Entry)
+com.android.volley.ResponseDelivery: class public abstract interface
+com.android.volley.ResponseDelivery: method public abstract void com.android.volley.ResponseDelivery.postError(com.android.volley.Request<?>,com.android.volley.VolleyError)
+com.android.volley.ResponseDelivery: method public abstract void com.android.volley.ResponseDelivery.postResponse(com.android.volley.Request<?>,com.android.volley.Response<?>)
+com.android.volley.ResponseDelivery: method public abstract void com.android.volley.ResponseDelivery.postResponse(com.android.volley.Request<?>,com.android.volley.Response<?>,java.lang.Runnable)
+com.android.volley.RetryPolicy: class public abstract interface
+com.android.volley.RetryPolicy: method public abstract int com.android.volley.RetryPolicy.getCurrentRetryCount()
+com.android.volley.RetryPolicy: method public abstract int com.android.volley.RetryPolicy.getCurrentTimeout()
+com.android.volley.RetryPolicy: method public abstract void com.android.volley.RetryPolicy.retry(com.android.volley.VolleyError) throws com.android.volley.VolleyError
+com.android.volley.ServerError: class public, extends com.android.volley.VolleyError
+com.android.volley.ServerError: ctor public com.android.volley.ServerError()
+com.android.volley.ServerError: ctor public com.android.volley.ServerError(com.android.volley.NetworkResponse)
+com.android.volley.TimeoutError: class public, extends com.android.volley.VolleyError
+com.android.volley.TimeoutError: ctor public com.android.volley.TimeoutError()
+com.android.volley.VolleyError: class public, extends java.lang.Exception
+com.android.volley.VolleyError: ctor public com.android.volley.VolleyError()
+com.android.volley.VolleyError: ctor public com.android.volley.VolleyError(com.android.volley.NetworkResponse)
+com.android.volley.VolleyError: ctor public com.android.volley.VolleyError(java.lang.String)
+com.android.volley.VolleyError: ctor public com.android.volley.VolleyError(java.lang.String,java.lang.Throwable)
+com.android.volley.VolleyError: ctor public com.android.volley.VolleyError(java.lang.Throwable)
+com.android.volley.VolleyError: field public final com.android.volley.NetworkResponse com.android.volley.VolleyError.networkResponse
+com.android.volley.VolleyError: method public long com.android.volley.VolleyError.getNetworkTimeMs()
+com.android.volley.VolleyLog: class public
+com.android.volley.VolleyLog: ctor public com.android.volley.VolleyLog()
+com.android.volley.VolleyLog: field public static boolean com.android.volley.VolleyLog.DEBUG
+com.android.volley.VolleyLog: field public static java.lang.String com.android.volley.VolleyLog.TAG
+com.android.volley.VolleyLog: method public static void com.android.volley.VolleyLog.d(java.lang.String,java.lang.Object...)
+com.android.volley.VolleyLog: method public static void com.android.volley.VolleyLog.e(java.lang.String,java.lang.Object...)
+com.android.volley.VolleyLog: method public static void com.android.volley.VolleyLog.e(java.lang.Throwable,java.lang.String,java.lang.Object...)
+com.android.volley.VolleyLog: method public static void com.android.volley.VolleyLog.setTag(java.lang.String)
+com.android.volley.VolleyLog: method public static void com.android.volley.VolleyLog.v(java.lang.String,java.lang.Object...)
+com.android.volley.VolleyLog: method public static void com.android.volley.VolleyLog.wtf(java.lang.String,java.lang.Object...)
+com.android.volley.VolleyLog: method public static void com.android.volley.VolleyLog.wtf(java.lang.Throwable,java.lang.String,java.lang.Object...)
+com.android.volley.toolbox.AndroidAuthenticator: class public, implements com.android.volley.toolbox.Authenticator
+com.android.volley.toolbox.AndroidAuthenticator: ctor public com.android.volley.toolbox.AndroidAuthenticator(android.content.Context,android.accounts.Account,java.lang.String)
+com.android.volley.toolbox.AndroidAuthenticator: ctor public com.android.volley.toolbox.AndroidAuthenticator(android.content.Context,android.accounts.Account,java.lang.String,boolean)
+com.android.volley.toolbox.AndroidAuthenticator: method public android.accounts.Account com.android.volley.toolbox.AndroidAuthenticator.getAccount()
+com.android.volley.toolbox.AndroidAuthenticator: method public java.lang.String com.android.volley.toolbox.AndroidAuthenticator.getAuthToken() throws com.android.volley.AuthFailureError
+com.android.volley.toolbox.AndroidAuthenticator: method public java.lang.String com.android.volley.toolbox.AndroidAuthenticator.getAuthTokenType()
+com.android.volley.toolbox.AndroidAuthenticator: method public void com.android.volley.toolbox.AndroidAuthenticator.invalidateAuthToken(java.lang.String)
+com.android.volley.toolbox.Authenticator: class public abstract interface
+com.android.volley.toolbox.Authenticator: method public abstract java.lang.String com.android.volley.toolbox.Authenticator.getAuthToken() throws com.android.volley.AuthFailureError
+com.android.volley.toolbox.Authenticator: method public abstract void com.android.volley.toolbox.Authenticator.invalidateAuthToken(java.lang.String)
+com.android.volley.toolbox.BaseHttpStack: class public abstract, implements com.android.volley.toolbox.HttpStack
+com.android.volley.toolbox.BaseHttpStack: ctor public com.android.volley.toolbox.BaseHttpStack()
+com.android.volley.toolbox.BaseHttpStack: method public abstract com.android.volley.toolbox.HttpResponse com.android.volley.toolbox.BaseHttpStack.executeRequest(com.android.volley.Request<?>,java.util.Map<java.lang.String, java.lang.String>) throws java.io.IOException,com.android.volley.AuthFailureError
+com.android.volley.toolbox.BaseHttpStack: method public final org.apache.http.HttpResponse com.android.volley.toolbox.BaseHttpStack.performRequest(com.android.volley.Request<?>,java.util.Map<java.lang.String, java.lang.String>) throws java.io.IOException,com.android.volley.AuthFailureError
+com.android.volley.toolbox.BasicNetwork: class public, implements com.android.volley.Network
+com.android.volley.toolbox.BasicNetwork: ctor public com.android.volley.toolbox.BasicNetwork(com.android.volley.toolbox.BaseHttpStack)
+com.android.volley.toolbox.BasicNetwork: ctor public com.android.volley.toolbox.BasicNetwork(com.android.volley.toolbox.BaseHttpStack,com.android.volley.toolbox.ByteArrayPool)
+com.android.volley.toolbox.BasicNetwork: ctor public com.android.volley.toolbox.BasicNetwork(com.android.volley.toolbox.HttpStack)
+com.android.volley.toolbox.BasicNetwork: ctor public com.android.volley.toolbox.BasicNetwork(com.android.volley.toolbox.HttpStack,com.android.volley.toolbox.ByteArrayPool)
+com.android.volley.toolbox.BasicNetwork: field protected final com.android.volley.toolbox.ByteArrayPool com.android.volley.toolbox.BasicNetwork.mPool
+com.android.volley.toolbox.BasicNetwork: field protected final com.android.volley.toolbox.HttpStack com.android.volley.toolbox.BasicNetwork.mHttpStack
+com.android.volley.toolbox.BasicNetwork: field protected static final boolean com.android.volley.toolbox.BasicNetwork.DEBUG
+com.android.volley.toolbox.BasicNetwork: method protected static java.util.Map<java.lang.String, java.lang.String> com.android.volley.toolbox.BasicNetwork.convertHeaders(com.android.volley.Header[])
+com.android.volley.toolbox.BasicNetwork: method protected void com.android.volley.toolbox.BasicNetwork.logError(java.lang.String,java.lang.String,long)
+com.android.volley.toolbox.BasicNetwork: method public com.android.volley.NetworkResponse com.android.volley.toolbox.BasicNetwork.performRequest(com.android.volley.Request<?>) throws com.android.volley.VolleyError
+com.android.volley.toolbox.ByteArrayPool: class public
+com.android.volley.toolbox.ByteArrayPool: ctor public com.android.volley.toolbox.ByteArrayPool(int)
+com.android.volley.toolbox.ByteArrayPool: field protected static final java.util.Comparator<byte[]> com.android.volley.toolbox.ByteArrayPool.BUF_COMPARATOR
+com.android.volley.toolbox.ByteArrayPool: method public synchronized byte[] com.android.volley.toolbox.ByteArrayPool.getBuf(int)
+com.android.volley.toolbox.ByteArrayPool: method public synchronized void com.android.volley.toolbox.ByteArrayPool.returnBuf(byte[])
+com.android.volley.toolbox.ClearCacheRequest: class public, extends com.android.volley.Request
+com.android.volley.toolbox.ClearCacheRequest: ctor public com.android.volley.toolbox.ClearCacheRequest(com.android.volley.Cache,java.lang.Runnable)
+com.android.volley.toolbox.ClearCacheRequest: method protected com.android.volley.Response<java.lang.Object> com.android.volley.toolbox.ClearCacheRequest.parseNetworkResponse(com.android.volley.NetworkResponse)
+com.android.volley.toolbox.ClearCacheRequest: method protected void com.android.volley.toolbox.ClearCacheRequest.deliverResponse(java.lang.Object)
+com.android.volley.toolbox.ClearCacheRequest: method public boolean com.android.volley.toolbox.ClearCacheRequest.isCanceled()
+com.android.volley.toolbox.ClearCacheRequest: method public com.android.volley.Request$Priority com.android.volley.toolbox.ClearCacheRequest.getPriority()
+com.android.volley.toolbox.DiskBasedCache: class public, implements com.android.volley.Cache
+com.android.volley.toolbox.DiskBasedCache: ctor public com.android.volley.toolbox.DiskBasedCache(java.io.File)
+com.android.volley.toolbox.DiskBasedCache: ctor public com.android.volley.toolbox.DiskBasedCache(java.io.File,int)
+com.android.volley.toolbox.DiskBasedCache: method public java.io.File com.android.volley.toolbox.DiskBasedCache.getFileForKey(java.lang.String)
+com.android.volley.toolbox.DiskBasedCache: method public synchronized com.android.volley.Cache$Entry com.android.volley.toolbox.DiskBasedCache.get(java.lang.String)
+com.android.volley.toolbox.DiskBasedCache: method public synchronized void com.android.volley.toolbox.DiskBasedCache.clear()
+com.android.volley.toolbox.DiskBasedCache: method public synchronized void com.android.volley.toolbox.DiskBasedCache.initialize()
+com.android.volley.toolbox.DiskBasedCache: method public synchronized void com.android.volley.toolbox.DiskBasedCache.invalidate(java.lang.String,boolean)
+com.android.volley.toolbox.DiskBasedCache: method public synchronized void com.android.volley.toolbox.DiskBasedCache.put(java.lang.String,com.android.volley.Cache$Entry)
+com.android.volley.toolbox.DiskBasedCache: method public synchronized void com.android.volley.toolbox.DiskBasedCache.remove(java.lang.String)
+com.android.volley.toolbox.HttpClientStack$HttpPatch: class public static final, extends org.apache.http.client.methods.HttpEntityEnclosingRequestBase
+com.android.volley.toolbox.HttpClientStack$HttpPatch: ctor public com.android.volley.toolbox.HttpClientStack$HttpPatch()
+com.android.volley.toolbox.HttpClientStack$HttpPatch: ctor public com.android.volley.toolbox.HttpClientStack$HttpPatch(java.lang.String)
+com.android.volley.toolbox.HttpClientStack$HttpPatch: ctor public com.android.volley.toolbox.HttpClientStack$HttpPatch(java.net.URI)
+com.android.volley.toolbox.HttpClientStack$HttpPatch: field public static final java.lang.String com.android.volley.toolbox.HttpClientStack$HttpPatch.METHOD_NAME
+com.android.volley.toolbox.HttpClientStack$HttpPatch: method public java.lang.String com.android.volley.toolbox.HttpClientStack$HttpPatch.getMethod()
+com.android.volley.toolbox.HttpClientStack: class public, implements com.android.volley.toolbox.HttpStack
+com.android.volley.toolbox.HttpClientStack: ctor public com.android.volley.toolbox.HttpClientStack(org.apache.http.client.HttpClient)
+com.android.volley.toolbox.HttpClientStack: field protected final org.apache.http.client.HttpClient com.android.volley.toolbox.HttpClientStack.mClient
+com.android.volley.toolbox.HttpClientStack: method protected void com.android.volley.toolbox.HttpClientStack.onPrepareRequest(org.apache.http.client.methods.HttpUriRequest) throws java.io.IOException
+com.android.volley.toolbox.HttpClientStack: method public org.apache.http.HttpResponse com.android.volley.toolbox.HttpClientStack.performRequest(com.android.volley.Request<?>,java.util.Map<java.lang.String, java.lang.String>) throws java.io.IOException,com.android.volley.AuthFailureError
+com.android.volley.toolbox.HttpHeaderParser: class public
+com.android.volley.toolbox.HttpHeaderParser: ctor public com.android.volley.toolbox.HttpHeaderParser()
+com.android.volley.toolbox.HttpHeaderParser: method public static com.android.volley.Cache$Entry com.android.volley.toolbox.HttpHeaderParser.parseCacheHeaders(com.android.volley.NetworkResponse)
+com.android.volley.toolbox.HttpHeaderParser: method public static java.lang.String com.android.volley.toolbox.HttpHeaderParser.parseCharset(java.util.Map<java.lang.String, java.lang.String>)
+com.android.volley.toolbox.HttpHeaderParser: method public static java.lang.String com.android.volley.toolbox.HttpHeaderParser.parseCharset(java.util.Map<java.lang.String, java.lang.String>,java.lang.String)
+com.android.volley.toolbox.HttpHeaderParser: method public static long com.android.volley.toolbox.HttpHeaderParser.parseDateAsEpoch(java.lang.String)
+com.android.volley.toolbox.HttpResponse: class public final
+com.android.volley.toolbox.HttpResponse: ctor public com.android.volley.toolbox.HttpResponse(int,java.util.List<com.android.volley.Header>)
+com.android.volley.toolbox.HttpResponse: ctor public com.android.volley.toolbox.HttpResponse(int,java.util.List<com.android.volley.Header>,int,java.io.InputStream)
+com.android.volley.toolbox.HttpResponse: method public final int com.android.volley.toolbox.HttpResponse.getContentLength()
+com.android.volley.toolbox.HttpResponse: method public final int com.android.volley.toolbox.HttpResponse.getStatusCode()
+com.android.volley.toolbox.HttpResponse: method public final java.io.InputStream com.android.volley.toolbox.HttpResponse.getContent()
+com.android.volley.toolbox.HttpResponse: method public final java.util.List<com.android.volley.Header> com.android.volley.toolbox.HttpResponse.getHeaders()
+com.android.volley.toolbox.HttpStack: class public abstract interface
+com.android.volley.toolbox.HttpStack: method public abstract org.apache.http.HttpResponse com.android.volley.toolbox.HttpStack.performRequest(com.android.volley.Request<?>,java.util.Map<java.lang.String, java.lang.String>) throws java.io.IOException,com.android.volley.AuthFailureError
+com.android.volley.toolbox.HurlStack$UrlRewriter: class public abstract static interface
+com.android.volley.toolbox.HurlStack$UrlRewriter: method public abstract java.lang.String com.android.volley.toolbox.HurlStack$UrlRewriter.rewriteUrl(java.lang.String)
+com.android.volley.toolbox.HurlStack: class public, extends com.android.volley.toolbox.BaseHttpStack
+com.android.volley.toolbox.HurlStack: ctor public com.android.volley.toolbox.HurlStack()
+com.android.volley.toolbox.HurlStack: ctor public com.android.volley.toolbox.HurlStack(com.android.volley.toolbox.HurlStack$UrlRewriter)
+com.android.volley.toolbox.HurlStack: ctor public com.android.volley.toolbox.HurlStack(com.android.volley.toolbox.HurlStack$UrlRewriter,javax.net.ssl.SSLSocketFactory)
+com.android.volley.toolbox.HurlStack: method protected java.net.HttpURLConnection com.android.volley.toolbox.HurlStack.createConnection(java.net.URL) throws java.io.IOException
+com.android.volley.toolbox.HurlStack: method public com.android.volley.toolbox.HttpResponse com.android.volley.toolbox.HurlStack.executeRequest(com.android.volley.Request<?>,java.util.Map<java.lang.String, java.lang.String>) throws java.io.IOException,com.android.volley.AuthFailureError
+com.android.volley.toolbox.ImageLoader$ImageCache: class public abstract static interface
+com.android.volley.toolbox.ImageLoader$ImageCache: method public abstract android.graphics.Bitmap com.android.volley.toolbox.ImageLoader$ImageCache.getBitmap(java.lang.String)
+com.android.volley.toolbox.ImageLoader$ImageCache: method public abstract void com.android.volley.toolbox.ImageLoader$ImageCache.putBitmap(java.lang.String,android.graphics.Bitmap)
+com.android.volley.toolbox.ImageLoader$ImageContainer: class public
+com.android.volley.toolbox.ImageLoader$ImageContainer: ctor public com.android.volley.toolbox.ImageLoader$ImageContainer(com.android.volley.toolbox.ImageLoader,android.graphics.Bitmap,java.lang.String,java.lang.String,com.android.volley.toolbox.ImageLoader$ImageListener)
+com.android.volley.toolbox.ImageLoader$ImageContainer: method public android.graphics.Bitmap com.android.volley.toolbox.ImageLoader$ImageContainer.getBitmap()
+com.android.volley.toolbox.ImageLoader$ImageContainer: method public java.lang.String com.android.volley.toolbox.ImageLoader$ImageContainer.getRequestUrl()
+com.android.volley.toolbox.ImageLoader$ImageContainer: method public void com.android.volley.toolbox.ImageLoader$ImageContainer.cancelRequest()
+com.android.volley.toolbox.ImageLoader$ImageListener: class public abstract static interface, implements com.android.volley.Response$ErrorListener
+com.android.volley.toolbox.ImageLoader$ImageListener: method public abstract void com.android.volley.toolbox.ImageLoader$ImageListener.onResponse(com.android.volley.toolbox.ImageLoader$ImageContainer,boolean)
+com.android.volley.toolbox.ImageLoader: class public
+com.android.volley.toolbox.ImageLoader: ctor public com.android.volley.toolbox.ImageLoader(com.android.volley.RequestQueue,com.android.volley.toolbox.ImageLoader$ImageCache)
+com.android.volley.toolbox.ImageLoader: method protected com.android.volley.Request<android.graphics.Bitmap> com.android.volley.toolbox.ImageLoader.makeImageRequest(java.lang.String,int,int,android.widget.ImageView$ScaleType,java.lang.String)
+com.android.volley.toolbox.ImageLoader: method protected void com.android.volley.toolbox.ImageLoader.onGetImageError(java.lang.String,com.android.volley.VolleyError)
+com.android.volley.toolbox.ImageLoader: method protected void com.android.volley.toolbox.ImageLoader.onGetImageSuccess(java.lang.String,android.graphics.Bitmap)
+com.android.volley.toolbox.ImageLoader: method public boolean com.android.volley.toolbox.ImageLoader.isCached(java.lang.String,int,int)
+com.android.volley.toolbox.ImageLoader: method public boolean com.android.volley.toolbox.ImageLoader.isCached(java.lang.String,int,int,android.widget.ImageView$ScaleType)
+com.android.volley.toolbox.ImageLoader: method public com.android.volley.toolbox.ImageLoader$ImageContainer com.android.volley.toolbox.ImageLoader.get(java.lang.String,com.android.volley.toolbox.ImageLoader$ImageListener)
+com.android.volley.toolbox.ImageLoader: method public com.android.volley.toolbox.ImageLoader$ImageContainer com.android.volley.toolbox.ImageLoader.get(java.lang.String,com.android.volley.toolbox.ImageLoader$ImageListener,int,int)
+com.android.volley.toolbox.ImageLoader: method public com.android.volley.toolbox.ImageLoader$ImageContainer com.android.volley.toolbox.ImageLoader.get(java.lang.String,com.android.volley.toolbox.ImageLoader$ImageListener,int,int,android.widget.ImageView$ScaleType)
+com.android.volley.toolbox.ImageLoader: method public static com.android.volley.toolbox.ImageLoader$ImageListener com.android.volley.toolbox.ImageLoader.getImageListener(android.widget.ImageView,int,int)
+com.android.volley.toolbox.ImageLoader: method public void com.android.volley.toolbox.ImageLoader.setBatchedResponseDelay(int)
+com.android.volley.toolbox.ImageRequest: class public, extends com.android.volley.Request
+com.android.volley.toolbox.ImageRequest: ctor public com.android.volley.toolbox.ImageRequest(java.lang.String,com.android.volley.Response.com.android.volley.Response$Listener<android.graphics.Bitmap>,int,int,android.graphics.Bitmap$Config,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.ImageRequest: ctor public com.android.volley.toolbox.ImageRequest(java.lang.String,com.android.volley.Response.com.android.volley.Response$Listener<android.graphics.Bitmap>,int,int,android.widget.ImageView$ScaleType,android.graphics.Bitmap$Config,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.ImageRequest: field public static final float com.android.volley.toolbox.ImageRequest.DEFAULT_IMAGE_BACKOFF_MULT
+com.android.volley.toolbox.ImageRequest: field public static final int com.android.volley.toolbox.ImageRequest.DEFAULT_IMAGE_MAX_RETRIES
+com.android.volley.toolbox.ImageRequest: field public static final int com.android.volley.toolbox.ImageRequest.DEFAULT_IMAGE_TIMEOUT_MS
+com.android.volley.toolbox.ImageRequest: method protected com.android.volley.Response<android.graphics.Bitmap> com.android.volley.toolbox.ImageRequest.parseNetworkResponse(com.android.volley.NetworkResponse)
+com.android.volley.toolbox.ImageRequest: method protected void com.android.volley.toolbox.ImageRequest.deliverResponse(android.graphics.Bitmap)
+com.android.volley.toolbox.ImageRequest: method protected void com.android.volley.toolbox.ImageRequest.deliverResponse(java.lang.Object)
+com.android.volley.toolbox.ImageRequest: method public com.android.volley.Request$Priority com.android.volley.toolbox.ImageRequest.getPriority()
+com.android.volley.toolbox.ImageRequest: method public void com.android.volley.toolbox.ImageRequest.cancel()
+com.android.volley.toolbox.JsonArrayRequest: class public, extends com.android.volley.toolbox.JsonRequest
+com.android.volley.toolbox.JsonArrayRequest: ctor public com.android.volley.toolbox.JsonArrayRequest(int,java.lang.String,org.json.JSONArray,com.android.volley.Response.com.android.volley.Response$Listener<org.json.JSONArray>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.JsonArrayRequest: ctor public com.android.volley.toolbox.JsonArrayRequest(java.lang.String,com.android.volley.Response.com.android.volley.Response$Listener<org.json.JSONArray>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.JsonArrayRequest: method protected com.android.volley.Response<org.json.JSONArray> com.android.volley.toolbox.JsonArrayRequest.parseNetworkResponse(com.android.volley.NetworkResponse)
+com.android.volley.toolbox.JsonObjectRequest: class public, extends com.android.volley.toolbox.JsonRequest
+com.android.volley.toolbox.JsonObjectRequest: ctor public com.android.volley.toolbox.JsonObjectRequest(int,java.lang.String,org.json.JSONObject,com.android.volley.Response.com.android.volley.Response$Listener<org.json.JSONObject>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.JsonObjectRequest: ctor public com.android.volley.toolbox.JsonObjectRequest(java.lang.String,org.json.JSONObject,com.android.volley.Response.com.android.volley.Response$Listener<org.json.JSONObject>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.JsonObjectRequest: method protected com.android.volley.Response<org.json.JSONObject> com.android.volley.toolbox.JsonObjectRequest.parseNetworkResponse(com.android.volley.NetworkResponse)
+com.android.volley.toolbox.JsonRequest: class public abstract, extends com.android.volley.Request
+com.android.volley.toolbox.JsonRequest: ctor public com.android.volley.toolbox.JsonRequest(int,java.lang.String,java.lang.String,com.android.volley.Response.com.android.volley.Response$Listener<T>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.JsonRequest: ctor public com.android.volley.toolbox.JsonRequest(java.lang.String,java.lang.String,com.android.volley.Response.com.android.volley.Response$Listener<T>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.JsonRequest: field protected static final java.lang.String com.android.volley.toolbox.JsonRequest.PROTOCOL_CHARSET
+com.android.volley.toolbox.JsonRequest: method protected abstract com.android.volley.Response<T> com.android.volley.toolbox.JsonRequest.parseNetworkResponse(com.android.volley.NetworkResponse)
+com.android.volley.toolbox.JsonRequest: method protected void com.android.volley.toolbox.JsonRequest.deliverResponse(T)
+com.android.volley.toolbox.JsonRequest: method public byte[] com.android.volley.toolbox.JsonRequest.getBody()
+com.android.volley.toolbox.JsonRequest: method public byte[] com.android.volley.toolbox.JsonRequest.getPostBody()
+com.android.volley.toolbox.JsonRequest: method public java.lang.String com.android.volley.toolbox.JsonRequest.getBodyContentType()
+com.android.volley.toolbox.JsonRequest: method public java.lang.String com.android.volley.toolbox.JsonRequest.getPostBodyContentType()
+com.android.volley.toolbox.JsonRequest: method public void com.android.volley.toolbox.JsonRequest.cancel()
+com.android.volley.toolbox.NetworkImageView: class public, extends android.widget.ImageView
+com.android.volley.toolbox.NetworkImageView: ctor public com.android.volley.toolbox.NetworkImageView(android.content.Context)
+com.android.volley.toolbox.NetworkImageView: ctor public com.android.volley.toolbox.NetworkImageView(android.content.Context,android.util.AttributeSet)
+com.android.volley.toolbox.NetworkImageView: ctor public com.android.volley.toolbox.NetworkImageView(android.content.Context,android.util.AttributeSet,int)
+com.android.volley.toolbox.NetworkImageView: method protected void com.android.volley.toolbox.NetworkImageView.drawableStateChanged()
+com.android.volley.toolbox.NetworkImageView: method protected void com.android.volley.toolbox.NetworkImageView.onDetachedFromWindow()
+com.android.volley.toolbox.NetworkImageView: method protected void com.android.volley.toolbox.NetworkImageView.onLayout(boolean,int,int,int,int)
+com.android.volley.toolbox.NetworkImageView: method public void com.android.volley.toolbox.NetworkImageView.setDefaultImageResId(int)
+com.android.volley.toolbox.NetworkImageView: method public void com.android.volley.toolbox.NetworkImageView.setErrorImageResId(int)
+com.android.volley.toolbox.NetworkImageView: method public void com.android.volley.toolbox.NetworkImageView.setImageUrl(java.lang.String,com.android.volley.toolbox.ImageLoader)
+com.android.volley.toolbox.NoCache: class public, implements com.android.volley.Cache
+com.android.volley.toolbox.NoCache: ctor public com.android.volley.toolbox.NoCache()
+com.android.volley.toolbox.NoCache: method public com.android.volley.Cache$Entry com.android.volley.toolbox.NoCache.get(java.lang.String)
+com.android.volley.toolbox.NoCache: method public void com.android.volley.toolbox.NoCache.clear()
+com.android.volley.toolbox.NoCache: method public void com.android.volley.toolbox.NoCache.initialize()
+com.android.volley.toolbox.NoCache: method public void com.android.volley.toolbox.NoCache.invalidate(java.lang.String,boolean)
+com.android.volley.toolbox.NoCache: method public void com.android.volley.toolbox.NoCache.put(java.lang.String,com.android.volley.Cache$Entry)
+com.android.volley.toolbox.NoCache: method public void com.android.volley.toolbox.NoCache.remove(java.lang.String)
+com.android.volley.toolbox.PoolingByteArrayOutputStream: class public, extends java.io.ByteArrayOutputStream
+com.android.volley.toolbox.PoolingByteArrayOutputStream: ctor public com.android.volley.toolbox.PoolingByteArrayOutputStream(com.android.volley.toolbox.ByteArrayPool)
+com.android.volley.toolbox.PoolingByteArrayOutputStream: ctor public com.android.volley.toolbox.PoolingByteArrayOutputStream(com.android.volley.toolbox.ByteArrayPool,int)
+com.android.volley.toolbox.PoolingByteArrayOutputStream: method public synchronized void com.android.volley.toolbox.PoolingByteArrayOutputStream.write(byte[],int,int)
+com.android.volley.toolbox.PoolingByteArrayOutputStream: method public synchronized void com.android.volley.toolbox.PoolingByteArrayOutputStream.write(int)
+com.android.volley.toolbox.PoolingByteArrayOutputStream: method public void com.android.volley.toolbox.PoolingByteArrayOutputStream.close() throws java.io.IOException
+com.android.volley.toolbox.PoolingByteArrayOutputStream: method public void com.android.volley.toolbox.PoolingByteArrayOutputStream.finalize()
+com.android.volley.toolbox.RequestFuture: class public, implements java.util.concurrent.Future com.android.volley.Response$Listener com.android.volley.Response$ErrorListener
+com.android.volley.toolbox.RequestFuture: method public T com.android.volley.toolbox.RequestFuture.get() throws java.lang.InterruptedException,java.util.concurrent.ExecutionException
+com.android.volley.toolbox.RequestFuture: method public T com.android.volley.toolbox.RequestFuture.get(long,java.util.concurrent.TimeUnit) throws java.lang.InterruptedException,java.util.concurrent.ExecutionException,java.util.concurrent.TimeoutException
+com.android.volley.toolbox.RequestFuture: method public boolean com.android.volley.toolbox.RequestFuture.isCancelled()
+com.android.volley.toolbox.RequestFuture: method public static <E> com.android.volley.toolbox.RequestFuture<E> com.android.volley.toolbox.RequestFuture.newFuture()
+com.android.volley.toolbox.RequestFuture: method public synchronized boolean com.android.volley.toolbox.RequestFuture.cancel(boolean)
+com.android.volley.toolbox.RequestFuture: method public synchronized boolean com.android.volley.toolbox.RequestFuture.isDone()
+com.android.volley.toolbox.RequestFuture: method public synchronized void com.android.volley.toolbox.RequestFuture.onErrorResponse(com.android.volley.VolleyError)
+com.android.volley.toolbox.RequestFuture: method public synchronized void com.android.volley.toolbox.RequestFuture.onResponse(T)
+com.android.volley.toolbox.RequestFuture: method public void com.android.volley.toolbox.RequestFuture.setRequest(com.android.volley.Request<?>)
+com.android.volley.toolbox.StringRequest: class public, extends com.android.volley.Request
+com.android.volley.toolbox.StringRequest: ctor public com.android.volley.toolbox.StringRequest(int,java.lang.String,com.android.volley.Response.com.android.volley.Response$Listener<java.lang.String>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.StringRequest: ctor public com.android.volley.toolbox.StringRequest(java.lang.String,com.android.volley.Response.com.android.volley.Response$Listener<java.lang.String>,com.android.volley.Response$ErrorListener)
+com.android.volley.toolbox.StringRequest: method protected com.android.volley.Response<java.lang.String> com.android.volley.toolbox.StringRequest.parseNetworkResponse(com.android.volley.NetworkResponse)
+com.android.volley.toolbox.StringRequest: method protected void com.android.volley.toolbox.StringRequest.deliverResponse(java.lang.Object)
+com.android.volley.toolbox.StringRequest: method protected void com.android.volley.toolbox.StringRequest.deliverResponse(java.lang.String)
+com.android.volley.toolbox.StringRequest: method public void com.android.volley.toolbox.StringRequest.cancel()
+com.android.volley.toolbox.Volley: class public
+com.android.volley.toolbox.Volley: ctor public com.android.volley.toolbox.Volley()
+com.android.volley.toolbox.Volley: method public static com.android.volley.RequestQueue com.android.volley.toolbox.Volley.newRequestQueue(android.content.Context)
+com.android.volley.toolbox.Volley: method public static com.android.volley.RequestQueue com.android.volley.toolbox.Volley.newRequestQueue(android.content.Context,com.android.volley.toolbox.BaseHttpStack)
+com.android.volley.toolbox.Volley: method public static com.android.volley.RequestQueue com.android.volley.toolbox.Volley.newRequestQueue(android.content.Context,com.android.volley.toolbox.HttpStack)


### PR DESCRIPTION
-All public/protected classes/methods/fields are considered public
 API. VolleyApisTest uses reflection to find all public APIs and
 compare against a golden list so that APIs are not accidentally
 changed in the future.

-A new .internal package can be used for any classes which need to
 be public but should not be depended on by Volley clients. Any
 class in this package will be obfuscated by Proguard and excluded
 from Javadocs in release artifacts.

This is a relatively simple approach compared to the doclava-based
approach used by the support library / Android platform, which isn't
worth the complexity. However, one drawback is that this cannot hide
public/protected parts of classes in the core Volley package.
Unfortunately, Proguard does not appear to support such a directive
(short of manually listing everything that needs to be kept).

Fixes #102