### PR TITLE
Add new JSON Response handler which can send any custom payload in re…

### DIFF
--- a/src/main/java/com/android/volley/toolbox/JsonCustomPayloadRequest.java
+++ b/src/main/java/com/android/volley/toolbox/JsonCustomPayloadRequest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import com.android.volley.AuthFailureError;
+import com.android.volley.NetworkResponse;
+import com.android.volley.ParseError;
+import com.android.volley.Request;
+import com.android.volley.Response;
+import com.android.volley.toolbox.HttpHeaderParser;
+import com.android.volley.toolbox.JsonObjectRequest;
+import com.android.volley.toolbox.JsonRequest;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+
+/**
+ * 
+ * A request for retrieving a {@link JSONObject} response body at a given URL, allowing for an
+ * optional Custome payload to be passed in as part of the request body.
+ *
+ */
+public class JsonCustomPayloadRequest extends Request<JSONObject> {
+
+    /** Default charset for request. */
+    protected static final String PROTOCOL_CHARSET = "utf-8";
+
+    /** Lock to guard mListener as it is cleared on cancel() and read on delivery. */
+    private final Object mLock = new Object();
+
+    // @GuardedBy("mLock")
+    private Response.Listener<JSONObject> mListener;
+    
+	/**
+     * Creates a new request.
+     * @param method the HTTP method to use
+     * @param url URL to fetch the JSON from
+     * @param listener Listener to receive the JSON response
+     * @param errorListener Error listener, or null to ignore errors.
+     */
+    public JsonCustomPayloadRequest(int method, String url, Response.Listener<JSONObject> listener,
+                       Response.ErrorListener errorListener) {
+        super(method, url, errorListener);
+        mListener = listener;
+    }
+
+    @Override
+    public void cancel() {
+        super.cancel();
+        synchronized (mLock) {
+            mListener = null;
+        }
+    }
+
+    @Override
+    protected void deliverResponse(JSONObject response) {
+        Response.Listener<JSONObject> listener;
+        synchronized (mLock) {
+            listener = mListener;
+        }
+        if (listener != null) {
+            listener.onResponse(response);
+        }
+    }
+
+    @Override
+    protected Response<JSONObject> parseNetworkResponse(NetworkResponse response) {
+        try {
+            String jsonString = new String(response.data,
+                    HttpHeaderParser.parseCharset(response.headers, PROTOCOL_CHARSET));
+
+            return Response.success(new JSONObject(jsonString),
+                    HttpHeaderParser.parseCacheHeaders(response));
+        } catch (UnsupportedEncodingException e) {
+            return Response.error(new ParseError(e));
+        } catch (JSONException je) {
+            return Response.error(new ParseError(je));
+        }
+    }
+}


### PR DESCRIPTION
Add new JSON Response handler which can send any custom payload in request body. My team required this feature in current ongoing project in which REST services was designed to accept url-encoded-form-data as request body but in reply generate JSON Object. 
This code is currently being used in the project, it may be a general requirement. Therefore I posted this code here if found useful you may incorporate this in main branch.