### PR TITLE
Use actual annotations instead of comments.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ apply plugin: 'com.android.library'
 
 repositories {
     jcenter()
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
 }
 
 group = 'com.android.volley'

--- a/rules.gradle
+++ b/rules.gradle
@@ -19,6 +19,10 @@ tasks.withType(JavaCompile) {
   options.compilerArgs << "-Werror"
 }
 
+dependencies {
+  provided "com.android.support:support-annotations:27.1.1"
+}
+
 // Check if the android plugin version supports unit testing.
 if (configurations.findByName("testCompile")) {
   dependencies {

--- a/src/main/java/com/android/volley/toolbox/AndroidAuthenticator.java
+++ b/src/main/java/com/android/volley/toolbox/AndroidAuthenticator.java
@@ -23,6 +23,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.VisibleForTesting;
 import com.android.volley.AuthFailureError;
 
 /**
@@ -61,7 +62,7 @@ public class AndroidAuthenticator implements Authenticator {
         this(AccountManager.get(context), account, authTokenType, notifyAuthFailure);
     }
 
-    // Visible for testing. Allows injection of a mock AccountManager.
+    @VisibleForTesting
     AndroidAuthenticator(
             AccountManager accountManager,
             Account account,

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -17,6 +17,7 @@
 package com.android.volley.toolbox;
 
 import android.os.SystemClock;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import com.android.volley.Cache;
 import com.android.volley.Header;
@@ -482,7 +483,7 @@ public class DiskBasedCache implements Cache {
         }
     }
 
-    // VisibleForTesting
+    @VisibleForTesting
     static class CountingInputStream extends FilterInputStream {
         private final long length;
         private long bytesRead;
@@ -510,7 +511,7 @@ public class DiskBasedCache implements Cache {
             return result;
         }
 
-        // VisibleForTesting
+        @VisibleForTesting
         long bytesRead() {
             return bytesRead;
         }

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -16,6 +16,7 @@
 
 package com.android.volley.toolbox;
 
+import android.support.annotation.VisibleForTesting;
 import com.android.volley.AuthFailureError;
 import com.android.volley.Header;
 import com.android.volley.Request;
@@ -106,7 +107,7 @@ public class HurlStack extends BaseHttpStack {
                 inputStreamFromConnection(connection));
     }
 
-    // VisibleForTesting
+    @VisibleForTesting
     static List<Header> convertHeaders(Map<String, List<String>> responseHeaders) {
         List<Header> headerList = new ArrayList<>(responseHeaders.size());
         for (Map.Entry<String, List<String>> entry : responseHeaders.entrySet()) {

--- a/src/main/java/com/android/volley/toolbox/ImageRequest.java
+++ b/src/main/java/com/android/volley/toolbox/ImageRequest.java
@@ -19,6 +19,8 @@ package com.android.volley.toolbox;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
 import android.graphics.BitmapFactory;
+import android.support.annotation.GuardedBy;
+import android.support.annotation.VisibleForTesting;
 import android.widget.ImageView.ScaleType;
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.NetworkResponse;
@@ -41,8 +43,9 @@ public class ImageRequest extends Request<Bitmap> {
     /** Lock to guard mListener as it is cleared on cancel() and read on delivery. */
     private final Object mLock = new Object();
 
-    // @GuardedBy("mLock")
+    @GuardedBy("mLock")
     private Response.Listener<Bitmap> mListener;
+
     private final Config mDecodeConfig;
     private final int mMaxWidth;
     private final int mMaxHeight;
@@ -262,7 +265,7 @@ public class ImageRequest extends Request<Bitmap> {
      * @param desiredWidth Desired width of the bitmap
      * @param desiredHeight Desired height of the bitmap
      */
-    // Visible for testing.
+    @VisibleForTesting
     static int findBestSampleSize(
             int actualWidth, int actualHeight, int desiredWidth, int desiredHeight) {
         double wr = (double) actualWidth / desiredWidth;

--- a/src/main/java/com/android/volley/toolbox/JsonRequest.java
+++ b/src/main/java/com/android/volley/toolbox/JsonRequest.java
@@ -16,6 +16,7 @@
 
 package com.android.volley.toolbox;
 
+import android.support.annotation.GuardedBy;
 import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
 import com.android.volley.Response;
@@ -41,8 +42,9 @@ public abstract class JsonRequest<T> extends Request<T> {
     /** Lock to guard mListener as it is cleared on cancel() and read on delivery. */
     private final Object mLock = new Object();
 
-    // @GuardedBy("mLock")
+    @GuardedBy("mLock")
     private Listener<T> mListener;
+
     private final String mRequestBody;
 
     /**

--- a/src/main/java/com/android/volley/toolbox/StringRequest.java
+++ b/src/main/java/com/android/volley/toolbox/StringRequest.java
@@ -16,6 +16,7 @@
 
 package com.android.volley.toolbox;
 
+import android.support.annotation.GuardedBy;
 import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
 import com.android.volley.Response;
@@ -29,7 +30,7 @@ public class StringRequest extends Request<String> {
     /** Lock to guard mListener as it is cleared on cancel() and read on delivery. */
     private final Object mLock = new Object();
 
-    // @GuardedBy("mLock")
+    @GuardedBy("mLock")
     private Listener<String> mListener;
 
     /**


### PR DESCRIPTION
Dependency on android.support.annotations is declared as "provided"
so it won't propagate to callers.

Note that by using the real `@GuardedBy`, ErrorProne now picks up on
places that a variable is accessed without a lock, so these had to
be fixed as well.

See #166 