### PR TITLE
Cleaning up parameter comments + unnecessary generics.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,5 +51,9 @@ android {
     buildToolsVersion = '25.0.2'
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xep:ParameterComment:ERROR"
+}
+
 apply from: 'rules.gradle'
 apply from: 'bintray.gradle'

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -271,7 +271,7 @@ public class CacheDispatcher extends Thread {
                 // There is already a request in flight. Queue up.
                 List<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
                 if (stagedRequests == null) {
-                    stagedRequests = new ArrayList<Request<?>>();
+                    stagedRequests = new ArrayList<>();
                 }
                 request.addMarker("waiting-for-response");
                 stagedRequests.add(request);

--- a/src/main/java/com/android/volley/NetworkResponse.java
+++ b/src/main/java/com/android/volley/NetworkResponse.java
@@ -80,7 +80,7 @@ public class NetworkResponse {
     @Deprecated
     public NetworkResponse(
             int statusCode, byte[] data, Map<String, String> headers, boolean notModified) {
-        this(statusCode, data, headers, notModified, 0);
+        this(statusCode, data, headers, notModified, /* networkTimeMs= */ 0);
     }
 
     /**
@@ -89,7 +89,12 @@ public class NetworkResponse {
      * @param data Response body
      */
     public NetworkResponse(byte[] data) {
-        this(HttpURLConnection.HTTP_OK, data, false, 0, Collections.<Header>emptyList());
+        this(
+                HttpURLConnection.HTTP_OK,
+                data,
+                /* notModified= */ false,
+                /* networkTimeMs= */ 0,
+                Collections.<Header>emptyList());
     }
 
     /**
@@ -103,7 +108,12 @@ public class NetworkResponse {
      */
     @Deprecated
     public NetworkResponse(byte[] data, Map<String, String> headers) {
-        this(HttpURLConnection.HTTP_OK, data, headers, false, 0);
+        this(
+                HttpURLConnection.HTTP_OK,
+                data,
+                headers,
+                /* notModified= */ false,
+                /* networkTimeMs= */ 0);
     }
 
     private NetworkResponse(

--- a/src/main/java/com/android/volley/RequestQueue.java
+++ b/src/main/java/com/android/volley/RequestQueue.java
@@ -47,7 +47,7 @@ public class RequestQueue {
      * The set of all requests currently being processed by this RequestQueue. A Request will be in
      * this set if it is waiting in any queue or currently being processed by any dispatcher.
      */
-    private final Set<Request<?>> mCurrentRequests = new HashSet<Request<?>>();
+    private final Set<Request<?>> mCurrentRequests = new HashSet<>();
 
     /** The cache triage queue. */
     private final PriorityBlockingQueue<Request<?>> mCacheQueue = new PriorityBlockingQueue<>();

--- a/src/main/java/com/android/volley/Response.java
+++ b/src/main/java/com/android/volley/Response.java
@@ -40,7 +40,7 @@ public class Response<T> {
 
     /** Returns a successful response containing the parsed result. */
     public static <T> Response<T> success(T result, Cache.Entry cacheEntry) {
-        return new Response<T>(result, cacheEntry);
+        return new Response<>(result, cacheEntry);
     }
 
     /**
@@ -48,7 +48,7 @@ public class Response<T> {
      * displayed to the user.
      */
     public static <T> Response<T> error(VolleyError error) {
-        return new Response<T>(error);
+        return new Response<>(error);
     }
 
     /** Parsed response, or null in the case of error. */

--- a/src/main/java/com/android/volley/VolleyLog.java
+++ b/src/main/java/com/android/volley/VolleyLog.java
@@ -123,7 +123,7 @@ public class VolleyLog {
             }
         }
 
-        private final List<Marker> mMarkers = new ArrayList<Marker>();
+        private final List<Marker> mMarkers = new ArrayList<>();
         private boolean mFinished = false;
 
         /** Adds a marker to this log with the specified name. */

--- a/src/main/java/com/android/volley/toolbox/AndroidAuthenticator.java
+++ b/src/main/java/com/android/volley/toolbox/AndroidAuthenticator.java
@@ -46,7 +46,7 @@ public class AndroidAuthenticator implements Authenticator {
      * @param authTokenType Auth token type passed to AccountManager
      */
     public AndroidAuthenticator(Context context, Account account, String authTokenType) {
-        this(context, account, authTokenType, false);
+        this(context, account, authTokenType, /* notifyAuthFailure= */ false);
     }
 
     /**
@@ -90,7 +90,11 @@ public class AndroidAuthenticator implements Authenticator {
     public String getAuthToken() throws AuthFailureError {
         AccountManagerFuture<Bundle> future =
                 mAccountManager.getAuthToken(
-                        mAccount, mAuthTokenType, mNotifyAuthFailure, null, null);
+                        mAccount,
+                        mAuthTokenType,
+                        mNotifyAuthFailure,
+                        /* callback= */ null,
+                        /* handler= */ null);
         Bundle result;
         try {
             result = future.getResult();

--- a/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
@@ -70,7 +70,7 @@ public abstract class BaseHttpStack implements HttpStack {
         ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
         StatusLine statusLine =
                 new BasicStatusLine(
-                        protocolVersion, response.getStatusCode(), "" /* reasonPhrase */);
+                        protocolVersion, response.getStatusCode(), /* reasonPhrase= */ "");
         BasicHttpResponse apacheResponse = new BasicHttpResponse(statusLine);
 
         List<org.apache.http.Header> headers = new ArrayList<>();

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -130,8 +130,8 @@ public class BasicNetwork implements Network {
                     if (entry == null) {
                         return new NetworkResponse(
                                 HttpURLConnection.HTTP_NOT_MODIFIED,
-                                null,
-                                true,
+                                /* data= */ null,
+                                /* notModified= */ true,
                                 SystemClock.elapsedRealtime() - requestStart,
                                 responseHeaders);
                     }
@@ -140,7 +140,7 @@ public class BasicNetwork implements Network {
                     return new NetworkResponse(
                             HttpURLConnection.HTTP_NOT_MODIFIED,
                             entry.data,
-                            true,
+                            /* notModified= */ true,
                             SystemClock.elapsedRealtime() - requestStart,
                             combinedHeaders);
                 }
@@ -166,7 +166,7 @@ public class BasicNetwork implements Network {
                 return new NetworkResponse(
                         statusCode,
                         responseContents,
-                        false,
+                        /* notModified= */ false,
                         SystemClock.elapsedRealtime() - requestStart,
                         responseHeaders);
             } catch (SocketTimeoutException e) {
@@ -187,7 +187,7 @@ public class BasicNetwork implements Network {
                             new NetworkResponse(
                                     statusCode,
                                     responseContents,
-                                    false,
+                                    /* notModified= */ false,
                                     SystemClock.elapsedRealtime() - requestStart,
                                     responseHeaders);
                     if (statusCode == HttpURLConnection.HTTP_UNAUTHORIZED

--- a/src/main/java/com/android/volley/toolbox/ByteArrayPool.java
+++ b/src/main/java/com/android/volley/toolbox/ByteArrayPool.java
@@ -53,7 +53,7 @@ public class ByteArrayPool {
     /** The buffer pool, arranged both by last use and by buffer size */
     private final List<byte[]> mBuffersByLastUse = new ArrayList<>();
 
-    private final List<byte[]> mBuffersBySize = new ArrayList<byte[]>(64);
+    private final List<byte[]> mBuffersBySize = new ArrayList<>(64);
 
     /** The total size of the buffers in the pool */
     private int mCurrentSize = 0;

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -50,8 +50,7 @@ import java.util.Map;
 public class DiskBasedCache implements Cache {
 
     /** Map of the Key, CacheHeader pairs */
-    private final Map<String, CacheHeader> mEntries =
-            new LinkedHashMap<String, CacheHeader>(16, .75f, true);
+    private final Map<String, CacheHeader> mEntries = new LinkedHashMap<>(16, .75f, true);
 
     /** Total amount of space currently used by the cache in bytes. */
     private long mTotalSize = 0;

--- a/src/main/java/com/android/volley/toolbox/HttpClientStack.java
+++ b/src/main/java/com/android/volley/toolbox/HttpClientStack.java
@@ -66,7 +66,7 @@ public class HttpClientStack implements HttpStack {
 
     @SuppressWarnings("unused")
     private static List<NameValuePair> getPostParameterPairs(Map<String, String> postParams) {
-        List<NameValuePair> result = new ArrayList<NameValuePair>(postParams.size());
+        List<NameValuePair> result = new ArrayList<>(postParams.size());
         for (String key : postParams.keySet()) {
             result.add(new BasicNameValuePair(key, postParams.get(key)));
         }

--- a/src/main/java/com/android/volley/toolbox/HttpResponse.java
+++ b/src/main/java/com/android/volley/toolbox/HttpResponse.java
@@ -35,7 +35,7 @@ public final class HttpResponse {
      * @param headers the response headers
      */
     public HttpResponse(int statusCode, List<Header> headers) {
-        this(statusCode, headers, -1 /* contentLength */, null /* content */);
+        this(statusCode, headers, /* contentLength= */ -1, /* content= */ null);
     }
 
     /**

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -51,12 +51,12 @@ public class HurlStack extends BaseHttpStack {
     private final SSLSocketFactory mSslSocketFactory;
 
     public HurlStack() {
-        this(null);
+        this(/* urlRewriter = */ null);
     }
 
     /** @param urlRewriter Rewriter to use for request URLs */
     public HurlStack(UrlRewriter urlRewriter) {
-        this(urlRewriter, null);
+        this(urlRewriter, /* sslSocketFactory = */ null);
     }
 
     /**

--- a/src/main/java/com/android/volley/toolbox/ImageLoader.java
+++ b/src/main/java/com/android/volley/toolbox/ImageLoader.java
@@ -1,12 +1,12 @@
-/**
+/*
  * Copyright (C) 2013 The Android Open Source Project
  *
- * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * Unless required by applicable law or agreed to in writing, software distributed under the
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
@@ -50,12 +50,10 @@ public class ImageLoader {
      * HashMap of Cache keys -> BatchedImageRequest used to track in-flight requests so that we can
      * coalesce multiple requests to the same URL into a single network request.
      */
-    private final HashMap<String, BatchedImageRequest> mInFlightRequests =
-            new HashMap<String, BatchedImageRequest>();
+    private final HashMap<String, BatchedImageRequest> mInFlightRequests = new HashMap<>();
 
     /** HashMap of the currently pending responses (waiting to be delivered). */
-    private final HashMap<String, BatchedImageRequest> mBatchedResponses =
-            new HashMap<String, BatchedImageRequest>();
+    private final HashMap<String, BatchedImageRequest> mBatchedResponses = new HashMap<>();
 
     /** Handler to the main thread. */
     private final Handler mHandler = new Handler(Looper.getMainLooper());
@@ -177,7 +175,7 @@ public class ImageLoader {
      * @param requestUrl The URL of the image to be loaded.
      */
     public ImageContainer get(String requestUrl, final ImageListener listener) {
-        return get(requestUrl, listener, 0, 0);
+        return get(requestUrl, listener, /* maxWidth= */ 0, /* maxHeight= */ 0);
     }
 
     /**
@@ -218,7 +216,9 @@ public class ImageLoader {
         Bitmap cachedBitmap = mCache.getBitmap(cacheKey);
         if (cachedBitmap != null) {
             // Return the cached bitmap.
-            ImageContainer container = new ImageContainer(cachedBitmap, requestUrl, null, null);
+            ImageContainer container =
+                    new ImageContainer(
+                            cachedBitmap, requestUrl, /* cacheKey= */ null, /* listener= */ null);
             imageListener.onResponse(container, true);
             return container;
         }

--- a/src/main/java/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkImageView.java
@@ -66,7 +66,7 @@ public class NetworkImageView extends ImageView {
         mUrl = url;
         mImageLoader = imageLoader;
         // The URL has potentially changed. See if we need to load it.
-        loadImageIfNecessary(false);
+        loadImageIfNecessary(/* isInLayoutPass= */ false);
     }
 
     /**
@@ -165,7 +165,7 @@ public class NetworkImageView extends ImageView {
                                             new Runnable() {
                                                 @Override
                                                 public void run() {
-                                                    onResponse(response, false);
+                                                    onResponse(response, /* isImmediate= */ false);
                                                 }
                                             });
                                     return;
@@ -194,7 +194,7 @@ public class NetworkImageView extends ImageView {
     @Override
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        loadImageIfNecessary(true);
+        loadImageIfNecessary(/* isInLayoutPass= */ true);
     }
 
     @Override

--- a/src/main/java/com/android/volley/toolbox/RequestFuture.java
+++ b/src/main/java/com/android/volley/toolbox/RequestFuture.java
@@ -59,7 +59,7 @@ public class RequestFuture<T> implements Future<T>, Response.Listener<T>, Respon
     private VolleyError mException;
 
     public static <E> RequestFuture<E> newFuture() {
-        return new RequestFuture<E>();
+        return new RequestFuture<>();
     }
 
     private RequestFuture() {}
@@ -85,7 +85,7 @@ public class RequestFuture<T> implements Future<T>, Response.Listener<T>, Respon
     @Override
     public T get() throws InterruptedException, ExecutionException {
         try {
-            return doGet(null);
+            return doGet(/* timeoutMs= */ null);
         } catch (TimeoutException e) {
             throw new AssertionError(e);
         }

--- a/src/main/java/com/android/volley/toolbox/Volley.java
+++ b/src/main/java/com/android/volley/toolbox/Volley.java
@@ -50,7 +50,8 @@ public class Volley {
                 String userAgent = "volley/0";
                 try {
                     String packageName = context.getPackageName();
-                    PackageInfo info = context.getPackageManager().getPackageInfo(packageName, 0);
+                    PackageInfo info =
+                            context.getPackageManager().getPackageInfo(packageName, /* flags= */ 0);
                     userAgent = packageName + "/" + info.versionCode;
                 } catch (NameNotFoundException e) {
                 }


### PR DESCRIPTION
Used diamond operator in all places it was possible.

For parameter comments, there's no way to automatically detect when
they "should" be present, but we can enforce that any that are there
adhere to the recommended style (which enables richer errorprone
checks). Took a manual pass to fix up some missing parameter tags,
but there may be others.

Diamond operators have been removed.

Test code is left unchanged to keep this tractable.

Fixes #166