### PR TITLE
Fix unchecked operations in Volley build.

### DIFF
--- a/rules.gradle
+++ b/rules.gradle
@@ -16,7 +16,7 @@ android {
 }
 
 tasks.withType(JavaCompile) {
-  options.compilerArgs << "-Werror"
+  options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
 dependencies {

--- a/src/main/java/com/android/volley/RequestQueue.java
+++ b/src/main/java/com/android/volley/RequestQueue.java
@@ -35,6 +35,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RequestQueue {
 
     /** Callback interface for completed requests. */
+    // TODO: This should not be a generic class, because the request type can't be determined at
+    // compile time, so all calls to onRequestFinished are unsafe. However, changing this would be
+    // an API-breaking change. See also: https://github.com/google/volley/pull/109
     public interface RequestFinishedListener<T> {
         /** Called when a request has finished processing. */
         void onRequestFinished(Request<T> request);
@@ -224,6 +227,7 @@ public class RequestQueue {
      * Called from {@link Request#finish(String)}, indicating that processing of the given request
      * has finished.
      */
+    @SuppressWarnings("unchecked") // see above note on RequestFinishedListener
     <T> void finish(Request<T> request) {
         // Remove from the set of requests currently being processed.
         synchronized (mCurrentRequests) {

--- a/src/test/java/com/android/volley/RequestQueueTest.java
+++ b/src/test/java/com/android/volley/RequestQueueTest.java
@@ -24,6 +24,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.android.volley.mock.ShadowSystemClock;
 import com.android.volley.toolbox.NoCache;
+import com.android.volley.toolbox.StringRequest;
 import com.android.volley.utils.ImmediateResponseDelivery;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,13 +52,13 @@ public class RequestQueueTest {
         RequestQueue queue = new RequestQueue(new NoCache(), mMockNetwork, 0, mDelivery);
         Object tagA = new Object();
         Object tagB = new Object();
-        Request req1 = mock(Request.class);
+        StringRequest req1 = mock(StringRequest.class);
         when(req1.getTag()).thenReturn(tagA);
-        Request req2 = mock(Request.class);
+        StringRequest req2 = mock(StringRequest.class);
         when(req2.getTag()).thenReturn(tagB);
-        Request req3 = mock(Request.class);
+        StringRequest req3 = mock(StringRequest.class);
         when(req3.getTag()).thenReturn(tagA);
-        Request req4 = mock(Request.class);
+        StringRequest req4 = mock(StringRequest.class);
         when(req4.getTag()).thenReturn(tagA);
 
         queue.add(req1); // A

--- a/src/test/java/com/android/volley/toolbox/AndroidAuthenticatorTest.java
+++ b/src/test/java/com/android/volley/toolbox/AndroidAuthenticatorTest.java
@@ -32,19 +32,20 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public class AndroidAuthenticatorTest {
-    private AccountManager mAccountManager;
+    @Mock private AccountManager mAccountManager;
+    @Mock private AccountManagerFuture<Bundle> mFuture;
     private Account mAccount;
-    private AccountManagerFuture<Bundle> mFuture;
     private AndroidAuthenticator mAuthenticator;
 
     @Before
     public void setUp() {
-        mAccountManager = mock(AccountManager.class);
-        mFuture = mock(AccountManagerFuture.class);
+        MockitoAnnotations.initMocks(this);
         mAccount = new Account("coolperson", "cooltype");
         mAuthenticator = new AndroidAuthenticator(mAccountManager, mAccount, "cooltype", false);
     }

--- a/src/test/java/com/android/volley/toolbox/ImageLoaderTest.java
+++ b/src/test/java/com/android/volley/toolbox/ImageLoaderTest.java
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
@@ -75,7 +76,7 @@ public class ImageLoaderTest {
         // Response callback should be called both times.
         verify(listener, times(2)).onResponse(any(ImageLoader.ImageContainer.class), eq(true));
         // But request should be enqueued only once.
-        verify(mRequestQueue, times(1)).add(any(Request.class));
+        verify(mRequestQueue, times(1)).add(Mockito.<Request<?>>any());
     }
 
     @Test


### PR DESCRIPTION
Also make them compiler errors.

Unfortunately in the case of RequestFinishedListener, we can only
suppress the warning, as the proper fix would change the public API.

Fixes #168