### PR TITLE
Fix concurrent modification errors in ImageContainer.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkImageView.java
@@ -14,6 +14,7 @@
 package com.android.volley.toolbox;
 
 import android.content.Context;
+import android.support.annotation.MainThread;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.ViewGroup.LayoutParams;
@@ -59,10 +60,14 @@ public class NetworkImageView extends ImageView {
      * <p>NOTE: If applicable, {@link NetworkImageView#setDefaultImageResId(int)} and {@link
      * NetworkImageView#setErrorImageResId(int)} should be called prior to calling this function.
      *
+     * <p>Must be called from the main thread.
+     *
      * @param url The URL that should be loaded into this ImageView.
      * @param imageLoader ImageLoader that will be used to make the request.
      */
+    @MainThread
     public void setImageUrl(String url, ImageLoader imageLoader) {
+        Threads.throwIfNotOnMainThread();
         mUrl = url;
         mImageLoader = imageLoader;
         // The URL has potentially changed. See if we need to load it.

--- a/src/main/java/com/android/volley/toolbox/Threads.java
+++ b/src/main/java/com/android/volley/toolbox/Threads.java
@@ -1,0 +1,13 @@
+package com.android.volley.toolbox;
+
+import android.os.Looper;
+
+final class Threads {
+    private Threads() {}
+
+    static void throwIfNotOnMainThread() {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            throw new IllegalStateException("Must be invoked from the main thread.");
+        }
+    }
+}


### PR DESCRIPTION
ImageContainer#cancelRequest modifies data structures that are
mutated without a lock on the main thread. Its parent class,
ImageLoader, is documented as requiring that all access happen
on the main thread, so strictly enforce that cancelRequest be
called from the main thread as well. Outside of cancelRequest,
the only uncontrolled caller is NetworkImageView#setImageUrl,
which we also document/enforce as needing to be called from the
main thread.

Add `@MainThread` annotations and Javadoc clarifications as
appropriate. Clarify that behavior on custom ResponseDeliveries
is undefined.

Fixes #132