### PR TITLE
Use different cache keys for different methods.

### DIFF
--- a/src/test/java/com/android/volley/RequestTest.java
+++ b/src/test/java/com/android/volley/RequestTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.android.volley.Request.Method;
 import com.android.volley.Request.Priority;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -84,9 +85,30 @@ public class RequestTest {
         assertFalse(0 == goodProtocol.getTrafficStatsTag());
     }
 
+    @Test
+    public void getCacheKey() {
+        assertEquals(
+                "http://example.com",
+                new UrlParseRequest(Method.GET, "http://example.com").getCacheKey());
+        assertEquals(
+                "http://example.com",
+                new UrlParseRequest(Method.DEPRECATED_GET_OR_POST, "http://example.com")
+                        .getCacheKey());
+        assertEquals(
+                "1-http://example.com",
+                new UrlParseRequest(Method.POST, "http://example.com").getCacheKey());
+        assertEquals(
+                "2-http://example.com",
+                new UrlParseRequest(Method.PUT, "http://example.com").getCacheKey());
+    }
+
     private static class UrlParseRequest extends Request<Object> {
-        public UrlParseRequest(String url) {
-            super(Request.Method.GET, url, null);
+        UrlParseRequest(String url) {
+            this(Method.GET, url);
+        }
+
+        UrlParseRequest(int method, String url) {
+            super(method, url, null);
         }
 
         @Override


### PR DESCRIPTION
RFC 7234 states that cache keys should contain both the request
method and target URI. Volley's was only including the URI.

However, simply changing the key as specified would result in
complete invalidation of existing caches, which, while technically
being safe, could have significant latency impact for many apps.
Given that the majority of cached requests should be using GET,
we omit the method for GET requests so that these cache entries
have the same key, while adding the method for other requests so
they don't collide unexpectedly.

This will result in a cache clear for apps which are reliant on
caching non-GET requests, which should be significantly rarer.

If caches were previously poisoned due to this bug, it's possible
they will remain poisoned until the cache entry expires. But this
is no worse than the previous behavior.

Finally - for DEPRECATED_GET_OR_POST, we can't tell which method
will be used, so we assume it is GET (identical to previous
behavior).

In a future release, we will disable POST caching by default, as
Volley's implementation is rarely going to be correct (and it is
far from trivial to implement correctly, which is why most caches
don't bother).

Fixes #154