### PR TITLE
Prevent duplicated/conflicting HTTP headers for HurlStack

### DIFF
--- a/src/main/java/com/android/volley/Request.java
+++ b/src/main/java/com/android/volley/Request.java
@@ -538,7 +538,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      * remaining, this will cause delivery of a {@link TimeoutError} error.
      */
     public final int getTimeoutMs() {
-        return mRetryPolicy.getCurrentTimeout();
+        return getRetryPolicy().getCurrentTimeout();
     }
 
     /** Returns the retry policy that should be used for this request. */

--- a/src/main/java/com/android/volley/toolbox/HttpClientStack.java
+++ b/src/main/java/com/android/volley/toolbox/HttpClientStack.java
@@ -58,7 +58,7 @@ public class HttpClientStack implements HttpStack {
         mClient = client;
     }
 
-    private static void addHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
+    private static void setHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
         for (String key : headers.keySet()) {
             httpRequest.setHeader(key, headers.get(key));
         }
@@ -77,8 +77,10 @@ public class HttpClientStack implements HttpStack {
     public HttpResponse performRequest(Request<?> request, Map<String, String> additionalHeaders)
             throws IOException, AuthFailureError {
         HttpUriRequest httpRequest = createHttpRequest(request, additionalHeaders);
-        addHeaders(httpRequest, additionalHeaders);
-        addHeaders(httpRequest, request.getHeaders());
+        setHeaders(httpRequest, additionalHeaders);
+        // Request.getHeaders() takes precedence over the given additional (cache) headers) and any
+        // headers set by createHttpRequest (like the Content-Type header).
+        setHeaders(httpRequest, request.getHeaders());
         onPrepareRequest(httpRequest);
         HttpParams httpParams = httpRequest.getParams();
         int timeoutMs = request.getTimeoutMs();

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -75,6 +75,7 @@ public class HurlStack extends BaseHttpStack {
         String url = request.getUrl();
         HashMap<String, String> map = new HashMap<>();
         map.putAll(additionalHeaders);
+        // Request.getHeaders() takes precedence over the given additional (cache) headers).
         map.putAll(request.getHeaders());
         if (mUrlRewriter != null) {
             String rewritten = mUrlRewriter.rewriteUrl(url);
@@ -88,6 +89,8 @@ public class HurlStack extends BaseHttpStack {
         boolean keepConnectionOpen = false;
         try {
             setConnectionParametersForRequest(connection, request);
+            // Apply the request headers last (they take precedence over any headers set by
+            // setConnectionParametersForRequest, like the Content-Type header).
             for (String headerName : map.keySet()) {
                 connection.setRequestProperty(headerName, map.get(headerName));
             }

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -88,7 +88,7 @@ public class HurlStack extends BaseHttpStack {
         boolean keepConnectionOpen = false;
         try {
             for (String headerName : map.keySet()) {
-                connection.addRequestProperty(headerName, map.get(headerName));
+                connection.setRequestProperty(headerName, map.get(headerName));
             }
             setConnectionParametersForRequest(connection, request);
             // Initialize HttpResponse with data from the HttpURLConnection.
@@ -281,7 +281,7 @@ public class HurlStack extends BaseHttpStack {
         // since this is handled by HttpURLConnection using the size of the prepared
         // output stream.
         connection.setDoOutput(true);
-        connection.addRequestProperty(
+        connection.setRequestProperty(
                 HttpHeaderParser.HEADER_CONTENT_TYPE, request.getBodyContentType());
         DataOutputStream out = new DataOutputStream(connection.getOutputStream());
         out.write(body);

--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -74,8 +74,8 @@ public class HurlStack extends BaseHttpStack {
             throws IOException, AuthFailureError {
         String url = request.getUrl();
         HashMap<String, String> map = new HashMap<>();
-        map.putAll(request.getHeaders());
         map.putAll(additionalHeaders);
+        map.putAll(request.getHeaders());
         if (mUrlRewriter != null) {
             String rewritten = mUrlRewriter.rewriteUrl(url);
             if (rewritten == null) {
@@ -87,10 +87,10 @@ public class HurlStack extends BaseHttpStack {
         HttpURLConnection connection = openConnection(parsedUrl, request);
         boolean keepConnectionOpen = false;
         try {
+            setConnectionParametersForRequest(connection, request);
             for (String headerName : map.keySet()) {
                 connection.setRequestProperty(headerName, map.get(headerName));
             }
-            setConnectionParametersForRequest(connection, request);
             // Initialize HttpResponse with data from the HttpURLConnection.
             int responseCode = connection.getResponseCode();
             if (responseCode == -1) {

--- a/src/test/java/com/android/volley/toolbox/HttpStackConformanceTest.java
+++ b/src/test/java/com/android/volley/toolbox/HttpStackConformanceTest.java
@@ -1,0 +1,173 @@
+package com.android.volley.toolbox;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.android.volley.Request;
+import com.android.volley.RetryPolicy;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests to validate that HttpStack implementations conform with expected behavior. */
+@RunWith(RobolectricTestRunner.class)
+public class HttpStackConformanceTest {
+    @Mock private RetryPolicy mMockRetryPolicy;
+    @Mock private Request mMockRequest;
+
+    @Mock private HttpURLConnection mMockConnection;
+    @Mock private OutputStream mMockOutputStream;
+    @Spy private HurlStack mHurlStack = new HurlStack();
+
+    @Mock private HttpClient mMockHttpClient;
+    private HttpClientStack mHttpClientStack;
+
+    private final TestCase[] mTestCases =
+            new TestCase[] {
+                // TestCase for HurlStack.
+                new TestCase() {
+                    @Override
+                    public HttpStack getStack() {
+                        return mHurlStack;
+                    }
+
+                    @Override
+                    public void setOutputHeaderMap(final Map<String, String> outputHeaderMap) {
+                        doAnswer(
+                                        new Answer<Void>() {
+                                            @Override
+                                            public Void answer(InvocationOnMock invocation)
+                                                    throws Throwable {
+                                                outputHeaderMap.put(
+                                                        invocation.<String>getArgument(0),
+                                                        invocation.<String>getArgument(1));
+                                                return null;
+                                            }
+                                        })
+                                .when(mMockConnection)
+                                .setRequestProperty(anyString(), anyString());
+                    }
+                },
+
+                // TestCase for HttpClientStack.
+                new TestCase() {
+                    @Override
+                    public HttpStack getStack() {
+                        return mHttpClientStack;
+                    }
+
+                    @Override
+                    public void setOutputHeaderMap(final Map<String, String> outputHeaderMap) {
+                        try {
+                            doAnswer(
+                                            new Answer<Void>() {
+                                                @Override
+                                                public Void answer(InvocationOnMock invocation)
+                                                        throws Throwable {
+                                                    HttpRequest request = invocation.getArgument(0);
+                                                    for (Header header : request.getAllHeaders()) {
+                                                        if (outputHeaderMap.containsKey(
+                                                                header.getName())) {
+                                                            fail(
+                                                                    "Multiple values for header "
+                                                                            + header.getName());
+                                                        }
+                                                        outputHeaderMap.put(
+                                                                header.getName(),
+                                                                header.getValue());
+                                                    }
+                                                    return null;
+                                                }
+                                            })
+                                    .when(mMockHttpClient)
+                                    .execute(any(HttpUriRequest.class));
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            };
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        mHttpClientStack = spy(new HttpClientStack(mMockHttpClient));
+
+        doReturn(mMockConnection).when(mHurlStack).createConnection(any(URL.class));
+        doReturn(mMockOutputStream).when(mMockConnection).getOutputStream();
+        when(mMockRequest.getUrl()).thenReturn("http://127.0.0.1");
+        when(mMockRequest.getRetryPolicy()).thenReturn(mMockRetryPolicy);
+    }
+
+    @Test
+    public void headerPrecedence() throws Exception {
+        Map<String, String> additionalHeaders = new HashMap<>();
+        additionalHeaders.put("A", "AddlA");
+        additionalHeaders.put("B", "AddlB");
+
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("A", "RequestA");
+        requestHeaders.put("C", "RequestC");
+        when(mMockRequest.getHeaders()).thenReturn(requestHeaders);
+
+        when(mMockRequest.getMethod()).thenReturn(Request.Method.POST);
+        when(mMockRequest.getBody()).thenReturn(new byte[0]);
+        when(mMockRequest.getBodyContentType()).thenReturn("BodyContentType");
+
+        for (TestCase testCase : mTestCases) {
+            // Test once without a Content-Type header in getHeaders().
+            Map<String, String> combinedHeaders = new HashMap<>();
+            testCase.setOutputHeaderMap(combinedHeaders);
+
+            testCase.getStack().performRequest(mMockRequest, additionalHeaders);
+
+            Map<String, String> expectedHeaders = new HashMap<>();
+            expectedHeaders.put("A", "RequestA");
+            expectedHeaders.put("B", "AddlB");
+            expectedHeaders.put("C", "RequestC");
+            expectedHeaders.put(HttpHeaderParser.HEADER_CONTENT_TYPE, "BodyContentType");
+
+            assertEquals(expectedHeaders, combinedHeaders);
+
+            // Reset and test again with a Content-Type header in getHeaders().
+            combinedHeaders.clear();
+
+            requestHeaders.put(HttpHeaderParser.HEADER_CONTENT_TYPE, "RequestContentType");
+            expectedHeaders.put(HttpHeaderParser.HEADER_CONTENT_TYPE, "RequestContentType");
+
+            testCase.getStack().performRequest(mMockRequest, additionalHeaders);
+            assertEquals(expectedHeaders, combinedHeaders);
+
+            // Clear the Content-Type header for the next TestCase.
+            requestHeaders.remove(HttpHeaderParser.HEADER_CONTENT_TYPE);
+        }
+    }
+
+    private interface TestCase {
+        HttpStack getStack();
+
+        void setOutputHeaderMap(Map<String, String> outputHeaderMap);
+    }
+}


### PR DESCRIPTION
- Don't send two Content-Type headers - let the getHeaders() one win out.
- Have getHeaders() values take precedence over cache headers

See #139 for more discussion and investigation.