### PR TITLE
Re-raise swallowed interrupts and log warnings for spurious

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -98,8 +98,12 @@ public class CacheDispatcher extends Thread {
             } catch (InterruptedException e) {
                 // We may have been interrupted because it was time to quit.
                 if (mQuit) {
+                    Thread.currentThread().interrupt();
                     return;
                 }
+                VolleyLog.e(
+                        "Ignoring spurious interrupt of CacheDispatcher thread; "
+                                + "use quit() to terminate it");
             }
         }
     }

--- a/src/main/java/com/android/volley/NetworkDispatcher.java
+++ b/src/main/java/com/android/volley/NetworkDispatcher.java
@@ -91,8 +91,12 @@ public class NetworkDispatcher extends Thread {
             } catch (InterruptedException e) {
                 // We may have been interrupted because it was time to quit.
                 if (mQuit) {
+                    Thread.currentThread().interrupt();
                     return;
                 }
+                VolleyLog.e(
+                        "Ignoring spurious interrupt of NetworkDispatcher thread; "
+                                + "use quit() to terminate it");
             }
         }
     }


### PR DESCRIPTION
interrupts.

Volley relies on a quit() method and mQuit flag on both dispatcher
threads to shut down those threads. These could just use the interrupt
state instead, but as noted on #60, these are public, non-final
classes, and so relying on interrupt depends on external callers and
subclasses using the interrupt state correctly.

To be more conservative and retain existing behavior, we keep the quit
method/flag around to ensure that we only shut down the dispatchers
when quit() is called. However, we re-raise the interrupt flag in this
case. If we're interrupted outside of quit(), we suppress the
interrupt flag and log a warning instead.

Fixes #60