### PR TITLE
Update NetworkImageView.java

### DIFF
--- a/src/main/java/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkImageView.java
@@ -40,7 +40,7 @@ public class NetworkImageView extends ImageView {
     /** Current ImageContainer. (either in-flight or finished) */
     private ImageContainer mImageContainer;
     
-    /** ImageLoader response listener interface */
+    /** ImageLoader response listener interface. */
     private ResponseListener mResponseListener;
 
     public NetworkImageView(Context context) {
@@ -157,7 +157,7 @@ public class NetworkImageView extends ImageView {
                                     setImageResource(mErrorImageId);
                                 }
 
-                                if(mResponseListener != null) {
+                                if (mResponseListener != null) {
                                     mResponseListener.onError();
                                 }
                             }
@@ -189,7 +189,7 @@ public class NetworkImageView extends ImageView {
                                     setImageResource(mDefaultImageId);
                                 }
 
-                                if(mResponseListener != null) {
+                                if (mResponseListener != null) {
                                     mResponseListener.onSuccess();
                                 }
                             }

--- a/src/main/java/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkImageView.java
@@ -39,6 +39,9 @@ public class NetworkImageView extends ImageView {
 
     /** Current ImageContainer. (either in-flight or finished) */
     private ImageContainer mImageContainer;
+    
+    /** ImageLoader response listener interface */
+    private ResponseListener mResponseListener;
 
     public NetworkImageView(Context context) {
         this(context, null);
@@ -153,6 +156,10 @@ public class NetworkImageView extends ImageView {
                                 if (mErrorImageId != 0) {
                                     setImageResource(mErrorImageId);
                                 }
+
+                                if(mResponseListener != null) {
+                                    mResponseListener.onError();
+                                }
                             }
 
                             @Override
@@ -180,6 +187,10 @@ public class NetworkImageView extends ImageView {
                                     setImageBitmap(response.getBitmap());
                                 } else if (mDefaultImageId != 0) {
                                     setImageResource(mDefaultImageId);
+                                }
+
+                                if(mResponseListener != null) {
+                                    mResponseListener.onSuccess();
                                 }
                             }
                         },
@@ -219,5 +230,14 @@ public class NetworkImageView extends ImageView {
     protected void drawableStateChanged() {
         super.drawableStateChanged();
         invalidate();
+    }
+
+    public interface ResponseListener {
+        public void onError();
+        public void onSuccess();
+    }
+
+    public void setResponseListener(ResponseListener listener) {
+        mResponseListener = listener;
     }
 }


### PR DESCRIPTION
Added an imageLoader response listener that triggers when image is loaded or not, onSuccess or onError.

My use case:
I am adding blurry effect to the loaded image, but I need to know when the image is downloaded and loaded to view before I can add the blurry effect to the image.

This update makes it possible with example below.


```
//set listener to view
imageView.setImageUrl(resourceUrl, imageLoader, new NetworkImageView.OnResponseListener() {
    @Override
     public void onSuccess(Bitmap bitmap) {
        //Todo: use the image resource
    }

    @Override
     public void onError(VolleyError error) {
        //Todo: handle error gracefully
    }
});
```