### PR TITLE
Fix the build.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -400,7 +400,7 @@ public class DiskBasedCache implements Cache {
                 long softTtl,
                 List<Header> allResponseHeaders) {
             this.key = key;
-            this.etag = ("".equals(etag)) ? null : etag;
+            this.etag = "".equals(etag) ? null : etag;
             this.serverDate = serverDate;
             this.lastModified = lastModified;
             this.ttl = ttl;


### PR DESCRIPTION
Volley's dependency on errorprone is is not fixed, so a new errorprone
check caused the build to fail. For now, just fix the issue. In the
future, we will migrate to a fixed version of errorprone, but this
change is non-trivial.

See #228