### PR TITLE
Bump Volley to 1.2.0-SNAPSHOT.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
 }
 
 group = 'com.android.volley'
-version = '1.1.2-SNAPSHOT'
+version = '1.2.0-SNAPSHOT'
 
 android {
     compileSdkVersion 25


### PR DESCRIPTION
1.1 appears stable and a new API will be added shortly in #227, with
more likely to follow in the future. In an emergency, we could fork
off a separate branch to continue 1.1 branch releases.