### PR TITLE
Add workaround for AssertionError at BasicNetwork

### DIFF
--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -264,8 +264,14 @@ public class BasicNetwork implements Network {
         }
 
         if (entry.lastModified > 0) {
-            headers.put(
-                    "If-Modified-Since", HttpHeaderParser.formatEpochAsRfc1123(entry.lastModified));
+            try {
+                headers.put(
+                        "If-Modified-Since", HttpHeaderParser.formatEpochAsRfc1123(entry.lastModified));
+            } catch (AssertionError e) {
+                // This can happen if corruption of filesystem.
+                // This is ASOP issue, We added workaround until that isssue is fixed.
+                VolleyLog.v("Error occurred when getting date from cache entry");
+            }   
         }
 
         return headers;


### PR DESCRIPTION
We have some issue about getting date from cache entry.
This is ASOP known issue, but I would like to add some workaround
until that issue is fixed.

Please refer to
https://issuetracker.google.com/issues/110848122

ISSUE=#177