### PR TITLE
Allow tracking of the request's life cycle

### DIFF
--- a/src/main/java/com/android/volley/NetworkDispatcher.java
+++ b/src/main/java/com/android/volley/NetworkDispatcher.java
@@ -114,6 +114,7 @@ public class NetworkDispatcher extends Thread {
     @VisibleForTesting
     void processRequest(Request<?> request) {
         long startTimeMs = SystemClock.elapsedRealtime();
+        request.sendEvent(RequestQueue.RequestEvent.REQUEST_PROCESSING_STARTED);
         try {
             request.addMarker("network-queue-take");
 
@@ -164,6 +165,8 @@ public class NetworkDispatcher extends Thread {
             volleyError.setNetworkTimeMs(SystemClock.elapsedRealtime() - startTimeMs);
             mDelivery.postError(request, volleyError);
             request.notifyListenerResponseNotUsable();
+        } finally {
+            request.sendEvent(RequestQueue.RequestEvent.REQUEST_PROCESSING_FINISHED);
         }
     }
 

--- a/src/main/java/com/android/volley/Request.java
+++ b/src/main/java/com/android/volley/Request.java
@@ -28,6 +28,7 @@ import com.android.volley.VolleyLog.MarkerLog;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -124,6 +125,8 @@ public abstract class Request<T> implements Comparable<Request<T>> {
     @GuardedBy("mLock")
     private NetworkRequestCompleteListener mRequestCompleteListener;
 
+    private Map<String, Object> mTags = new HashMap<>();
+
     /**
      * Creates a new request with the given URL and error listener. Note that the normal response
      * listener is not provided here as delivery of responses is provided by subclasses, who have a
@@ -174,6 +177,19 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      */
     public Object getTag() {
         return mTag;
+    }
+
+    public Request<?> setTag(String key, Object tag) {
+        mTags.put(key, tag);
+        return this;
+    }
+
+    public Object getTag(String key) {
+        return mTags.get(key);
+    }
+
+    public Object removeTag(String key) {
+        return mTags.remove(key);
     }
 
     /** @return this request's {@link com.android.volley.Response.ErrorListener}. */
@@ -248,6 +264,12 @@ public abstract class Request<T> implements Comparable<Request<T>> {
 
             mEventLog.add(tag, threadId);
             mEventLog.finish(this.toString());
+        }
+    }
+
+    void sendEvent(RequestQueue.RequestEvent event) {
+        if (mRequestQueue != null) {
+            mRequestQueue.sendRequestEvent(this, event);
         }
     }
 

--- a/src/test/java/com/android/volley/NetworkDispatcherTest.java
+++ b/src/test/java/com/android/volley/NetworkDispatcherTest.java
@@ -18,6 +18,7 @@ package com.android.volley;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,10 +27,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.android.volley.toolbox.NoCache;
 import com.android.volley.toolbox.StringRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,12 +74,81 @@ public class NetworkDispatcherTest {
     }
 
     @Test
+    public void successNotifiesListener() throws Exception {
+        final AtomicBoolean listenerWasCalledOnStart = new AtomicBoolean(false);
+        final AtomicBoolean listenerWasCalledOnFinish = new AtomicBoolean(false);
+
+        RequestQueue.RequestEventListener listener =
+                new RequestQueue.RequestEventListener() {
+                    @Override
+                    public void onRequestEvent(Request request, RequestQueue.RequestEvent event) {
+                        if (event == RequestQueue.RequestEvent.REQUEST_PROCESSING_STARTED) {
+                            if (listenerWasCalledOnStart.get()) {
+                                fail("Listener called more than once");
+                            }
+                            listenerWasCalledOnStart.set(true);
+                        } else if (event == RequestQueue.RequestEvent.REQUEST_PROCESSING_FINISHED) {
+                            if (listenerWasCalledOnFinish.get()) {
+                                fail("Listener called more than once");
+                            }
+                            listenerWasCalledOnFinish.set(true);
+                        }
+                    }
+                };
+        RequestQueue queue = new RequestQueue(new NoCache(), mNetwork, 0, mDelivery);
+        queue.addRequestEventListener(listener);
+        mRequest.setRequestQueue(queue);
+
+        when(mNetwork.performRequest(any(Request.class)))
+                .thenReturn(new NetworkResponse(CANNED_DATA));
+
+        mDispatcher.processRequest(mRequest);
+
+        assertTrue(listenerWasCalledOnStart.get());
+        assertTrue(listenerWasCalledOnFinish.get());
+    }
+
+    @Test
     public void exceptionPostsError() throws Exception {
         when(mNetwork.performRequest(any(Request.class))).thenThrow(new ServerError());
         mDispatcher.processRequest(mRequest);
 
         verify(mDelivery).postError(any(Request.class), any(VolleyError.class));
         verify(mDelivery, never()).postResponse(any(Request.class), any(Response.class));
+    }
+
+    @Test
+    public void exceptionNotifiesListener() throws Exception {
+        final AtomicBoolean listenerWasCalledOnStart = new AtomicBoolean(false);
+        final AtomicBoolean listenerWasCalledOnFinish = new AtomicBoolean(false);
+
+        RequestQueue.RequestEventListener listener =
+                new RequestQueue.RequestEventListener() {
+                    @Override
+                    public void onRequestEvent(Request request, RequestQueue.RequestEvent event) {
+                        if (event == RequestQueue.RequestEvent.REQUEST_PROCESSING_STARTED) {
+                            if (listenerWasCalledOnStart.get()) {
+                                fail("Listener called more than once");
+                            }
+                            listenerWasCalledOnStart.set(true);
+                        } else if (event == RequestQueue.RequestEvent.REQUEST_PROCESSING_FINISHED) {
+                            if (listenerWasCalledOnFinish.get()) {
+                                fail("Listener called more than once");
+                            }
+                            listenerWasCalledOnFinish.set(true);
+                        }
+                    }
+                };
+        RequestQueue queue = new RequestQueue(new NoCache(), mNetwork, 0, mDelivery);
+        queue.addRequestEventListener(listener);
+        mRequest.setRequestQueue(queue);
+
+        when(mNetwork.performRequest(any(Request.class))).thenThrow(new ServerError());
+
+        mDispatcher.processRequest(mRequest);
+
+        assertTrue(listenerWasCalledOnStart.get());
+        assertTrue(listenerWasCalledOnFinish.get());
     }
 
     @Test

--- a/src/test/java/com/android/volley/RequestTest.java
+++ b/src/test/java/com/android/volley/RequestTest.java
@@ -19,17 +19,29 @@ package com.android.volley;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.android.volley.Request.Method;
 import com.android.volley.Request.Priority;
+import com.android.volley.toolbox.NoCache;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 
 @RunWith(RobolectricTestRunner.class)
 public class RequestTest {
+    private @Mock ResponseDelivery mDelivery;
+    private @Mock Network mNetwork;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+    }
 
     @Test
     public void compareTo() {
@@ -188,5 +200,73 @@ public class RequestTest {
         } catch (IllegalArgumentException e) {
             // expected
         }
+    }
+
+    @Test
+    public void sendEvent_notifiesListeners() throws Exception {
+        final AtomicBoolean listenerWasCalled = new AtomicBoolean(false);
+
+        RequestQueue.RequestEventListener listener =
+                new RequestQueue.RequestEventListener() {
+                    @Override
+                    public void onRequestEvent(Request request, RequestQueue.RequestEvent event) {
+                        listenerWasCalled.set(true);
+                    }
+                };
+        RequestQueue queue = new RequestQueue(new NoCache(), mNetwork, 0, mDelivery);
+        queue.addRequestEventListener(listener);
+
+        Request<Object> request =
+                new Request<Object>(Method.POST, "url", null) {
+                    @Override
+                    protected void deliverResponse(Object response) {}
+
+                    @Override
+                    protected Response<Object> parseNetworkResponse(NetworkResponse response) {
+                        return null;
+                    }
+                };
+        request.setRequestQueue(queue);
+
+        request.sendEvent(RequestQueue.RequestEvent.REQUEST_PROCESSING_STARTED);
+
+        assertTrue(listenerWasCalled.get());
+    }
+
+    @Test
+    public void setTag_setsTag() throws Exception {
+        Request<Object> request =
+                new Request<Object>(Method.POST, "url", null) {
+                    @Override
+                    protected void deliverResponse(Object response) {}
+
+                    @Override
+                    protected Response<Object> parseNetworkResponse(NetworkResponse response) {
+                        return null;
+                    }
+                };
+
+        request.setTag("test", "123");
+
+        assertEquals("123", request.getTag("test"));
+    }
+
+    @Test
+    public void removeTag_removesTag() throws Exception {
+        Request<Object> request =
+                new Request<Object>(Method.POST, "url", null) {
+                    @Override
+                    protected void deliverResponse(Object response) {}
+
+                    @Override
+                    protected Response<Object> parseNetworkResponse(NetworkResponse response) {
+                        return null;
+                    }
+                };
+
+        request.setTag("test", "123");
+        request.removeTag("test");
+
+        assertEquals(null, request.getTag("test"));
     }
 }


### PR DESCRIPTION
Add request events listener which will be called on the request life
cycle events (queued, processing started, etc). Also add the ability to
associate data with the requests, without using other data structures,
which is useful when processing request life cycle events.