### PR TITLE
Clearing NetworkImageView's default image should always be safe.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/NetworkImageView.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkImageView.java
@@ -103,7 +103,7 @@ public class NetworkImageView extends ImageView {
      * <p>Cannot be called with {@link NetworkImageView#setDefaultImageBitmap}.
      */
     public void setDefaultImageResId(int defaultImage) {
-        if (mDefaultImageBitmap != null) {
+        if (defaultImage != 0 && mDefaultImageBitmap != null) {
             throw new IllegalArgumentException("Can't have a default image resource ID and bitmap");
         }
         mDefaultImageId = defaultImage;
@@ -115,8 +115,8 @@ public class NetworkImageView extends ImageView {
      *
      * <p>Cannot be called with {@link NetworkImageView#setDefaultImageResId}.
      */
-    public void setDefaultImageBitmap(Bitmap defaultImage) {
-        if (mDefaultImageId != 0) {
+    public void setDefaultImageBitmap(@Nullable Bitmap defaultImage) {
+        if (defaultImage != null && mDefaultImageId != 0) {
             throw new IllegalArgumentException("Can't have a default image resource ID and bitmap");
         }
         mDefaultImageBitmap = defaultImage;

--- a/src/test/java/com/android/volley/toolbox/NetworkImageViewTest.java
+++ b/src/test/java/com/android/volley/toolbox/NetworkImageViewTest.java
@@ -80,6 +80,21 @@ public class NetworkImageViewTest {
     }
 
     @Test
+    public void clearDefaultImageBitmapWithDefaultImageResId() {
+        mNIV.setDefaultImageResId(1);
+        // Clearing the default image should always be safe
+        mNIV.setDefaultImageBitmap(null);
+    }
+
+    @Test
+    public void clearDefaultImageResIdWithDefaultImageBitmap() {
+        Bitmap bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888);
+        mNIV.setDefaultImageBitmap(bitmap);
+        // Clearing the default image should always be safe
+        mNIV.setDefaultImageResId(0);
+    }
+
+    @Test
     public void publicMethods() throws Exception {
         // Catch-all test to find API-breaking changes.
         assertNotNull(NetworkImageView.class.getConstructor(Context.class));


### PR DESCRIPTION
This allows callers to pessimistically clear the default image before
setting a new one, if they're unsure which one is set. This is useful
for things like RecyclerViews.