### PR TITLE
Fix SNAPSHOT build deployment.

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1"
     }
 }
 


### PR DESCRIPTION
See https://github.com/jfrog/build-info/issues/166 - we were using an
older version of the plugin which was incompatible with the latest
Gradle version.