### PR TITLE
Pre-sized array is not recommended in HotSpot based JVMs

### DIFF
--- a/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/BaseHttpStack.java
@@ -77,7 +77,7 @@ public abstract class BaseHttpStack implements HttpStack {
         for (Header header : response.getHeaders()) {
             headers.add(new BasicHeader(header.getName(), header.getValue()));
         }
-        apacheResponse.setHeaders(headers.toArray(new org.apache.http.Header[headers.size()]));
+        apacheResponse.setHeaders(headers.toArray(new org.apache.http.Header[0]));
 
         InputStream responseStream = response.getContent();
         if (responseStream != null) {

--- a/src/test/java/com/android/volley/NetworkResponseTest.java
+++ b/src/test/java/com/android/volley/NetworkResponseTest.java
@@ -31,7 +31,7 @@ public class NetworkResponseTest {
 
         assertThat(
                 expectedHeaders,
-                containsInAnyOrder(resp.allHeaders.toArray(new Header[resp.allHeaders.size()])));
+                containsInAnyOrder(resp.allHeaders.toArray(new Header[0])));
     }
 
     @Test

--- a/src/test/java/com/android/volley/NetworkResponseTest.java
+++ b/src/test/java/com/android/volley/NetworkResponseTest.java
@@ -29,9 +29,7 @@ public class NetworkResponseTest {
         expectedHeaders.add(new Header("key1", "value1"));
         expectedHeaders.add(new Header("key2", "value2"));
 
-        assertThat(
-                expectedHeaders,
-                containsInAnyOrder(resp.allHeaders.toArray(new Header[0])));
+        assertThat(expectedHeaders, containsInAnyOrder(resp.allHeaders.toArray(new Header[0])));
     }
 
     @Test

--- a/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
@@ -155,10 +155,7 @@ public class BasicNetworkTest {
         expectedHeaders.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
         expectedHeaders.add(new Header("CachedKeyA", "CachedValueA"));
         expectedHeaders.add(new Header("CachedKeyB", "CachedValueB"));
-        assertThat(
-                expectedHeaders,
-                containsInAnyOrder(
-                        response.allHeaders.toArray(new Header[0])));
+        assertThat(expectedHeaders, containsInAnyOrder(response.allHeaders.toArray(new Header[0])));
     }
 
     @Test

--- a/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
@@ -121,10 +121,7 @@ public class BasicNetworkTest {
         expectedHeaders.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
         expectedHeaders.add(new Header("CachedKeyA", "CachedValueA"));
         expectedHeaders.add(new Header("CachedKeyB", "CachedValueB"));
-        assertThat(
-                expectedHeaders,
-                containsInAnyOrder(
-                        response.allHeaders.toArray(new Header[0])));
+        assertThat(expectedHeaders, containsInAnyOrder(response.allHeaders.toArray(new Header[0])));
     }
 
     @Test
@@ -161,7 +158,7 @@ public class BasicNetworkTest {
         assertThat(
                 expectedHeaders,
                 containsInAnyOrder(
-                        response.allHeaders.toArray(new Header[response.allHeaders.size()])));
+                        response.allHeaders.toArray(new Header[0])));
     }
 
     @Test

--- a/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicNetworkTest.java
@@ -124,7 +124,7 @@ public class BasicNetworkTest {
         assertThat(
                 expectedHeaders,
                 containsInAnyOrder(
-                        response.allHeaders.toArray(new Header[response.allHeaders.size()])));
+                        response.allHeaders.toArray(new Header[0])));
     }
 
     @Test


### PR DESCRIPTION
Empty-array is recommended in modern java

```java
Object[] objArray =  collection.toArray(new Object[0]);
```
