### PR TITLE
Send request to network when cache entry parsing fails

### DIFF
--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -159,6 +159,14 @@ public class CacheDispatcher extends Thread {
                             new NetworkResponse(entry.data, entry.responseHeaders));
             request.addMarker("cache-hit-parsed");
 
+            if (!response.isSuccess()) {
+                mCache.invalidate(request.getCacheKey(), true);
+                request.setCacheEntry(null);
+                if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {
+                    mNetworkQueue.put(request);
+                }
+                return;
+            }
             if (!entry.refreshNeeded()) {
                 // Completely unexpired cache hit. Just deliver the response.
                 mDelivery.postResponse(request, response);

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -160,6 +160,7 @@ public class CacheDispatcher extends Thread {
             request.addMarker("cache-hit-parsed");
 
             if (!response.isSuccess()) {
+                request.addMarker("cache-parsing-failed");
                 mCache.invalidate(request.getCacheKey(), true);
                 request.setCacheEntry(null);
                 if (!mWaitingRequestManager.maybeAddToWaitingRequests(request)) {

--- a/src/test/java/com/android/volley/CacheDispatcherTest.java
+++ b/src/test/java/com/android/volley/CacheDispatcherTest.java
@@ -156,6 +156,7 @@ public class CacheDispatcherTest {
         verify(mNetworkQueue).put(request);
         assertNull(request.getCacheEntry());
         verify(mCache).invalidate("cache/key", true);
+        verify(request).addMarker("cache-parsing-failed");
     }
 
     @Test


### PR DESCRIPTION
Also invalidate the corrupted cache entry and set the request's entry to null.

This is probably quite rare, but we should still rather send the request to the network than keep trying to return a potentially corrupted cache entry until it expires.