### PR TITLE
Tolerate null header maps in HttpHeaderParser.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
@@ -16,6 +16,7 @@
 
 package com.android.volley.toolbox;
 
+import androidx.annotation.Nullable;
 import com.android.volley.Cache;
 import com.android.volley.Header;
 import com.android.volley.NetworkResponse;
@@ -49,10 +50,14 @@ public class HttpHeaderParser {
      * @param response The network response to parse headers from
      * @return a cache entry for the given response, or null if the response is not cacheable.
      */
+    @Nullable
     public static Cache.Entry parseCacheHeaders(NetworkResponse response) {
         long now = System.currentTimeMillis();
 
         Map<String, String> headers = response.headers;
+        if (headers == null) {
+            return null;
+        }
 
         long serverDate = 0;
         long lastModified = 0;
@@ -171,7 +176,11 @@ public class HttpHeaderParser {
      * @return Returns the charset specified in the Content-Type of this header, or the
      *     defaultCharset if none can be found.
      */
-    public static String parseCharset(Map<String, String> headers, String defaultCharset) {
+    public static String parseCharset(
+            @Nullable Map<String, String> headers, String defaultCharset) {
+        if (headers == null) {
+            return defaultCharset;
+        }
         String contentType = headers.get(HEADER_CONTENT_TYPE);
         if (contentType != null) {
             String[] params = contentType.split(";", 0);
@@ -192,7 +201,7 @@ public class HttpHeaderParser {
      * Returns the charset specified in the Content-Type of this header, or the HTTP default
      * (ISO-8859-1) if none can be found.
      */
-    public static String parseCharset(Map<String, String> headers) {
+    public static String parseCharset(@Nullable Map<String, String> headers) {
         return parseCharset(headers, DEFAULT_CONTENT_CHARSET);
     }
 

--- a/src/test/java/com/android/volley/toolbox/HttpHeaderParserTest.java
+++ b/src/test/java/com/android/volley/toolbox/HttpHeaderParserTest.java
@@ -67,6 +67,12 @@ public class HttpHeaderParserTest {
     }
 
     @Test
+    public void parseCacheHeaders_nullHeaders() {
+        response = new NetworkResponse(0, null, null, false);
+        assertNull(HttpHeaderParser.parseCacheHeaders(response));
+    }
+
+    @Test
     public void parseCacheHeaders_headersSet() {
         headers.put("MyCustomHeader", "42");
 
@@ -282,6 +288,9 @@ public class HttpHeaderParserTest {
         // None specified, extra semicolon
         headers.put("Content-Type", "text/plain;");
         assertEquals("ISO-8859-1", HttpHeaderParser.parseCharset(headers));
+
+        // No headers, use default charset
+        assertEquals("utf-8", HttpHeaderParser.parseCharset(null, "utf-8"));
     }
 
     @Test


### PR DESCRIPTION
NetworkResponse#headers is documented as being nullable (now including
the `@Nullable` annotation), so we should be more tolerant of null values
when dealing with this field or header maps that commonly come from
this field.