### PR TITLE
Fix Android Studio project import of Volley.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ android {
     buildToolsVersion = '28.0.3'
 
     defaultConfig {
-        // Keep in sync with src/main/AndroidManifest.xml
         minSdkVersion 8
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,15 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.android.volley"
-    android:versionCode="1"
-    android:versionName="1.0" >
-
-    <!-- Keep in sync with build.gradle -->
-    <uses-sdk
-        android:minSdkVersion="8"
-        tools:ignore="GradleOverrides" />
-
-    <application />
-
-</manifest>
+<manifest package="com.android.volley" />

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -59,7 +59,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 16)
+@Config(sdk = 16)
 public class DiskBasedCacheTest {
 
     private static final int MAX_SIZE = 1024 * 1024;


### PR DESCRIPTION
- Remove minSdkVersion from AndroidManifest.xml since it is already specified
  in build.gradle. Other build systems will need to make similar changes to
  inject the minSdkVersion.

- Use -all instead of -bin for the gradle distribution to prevent AS from
  offering to change this upon first import.