### PR TITLE
Fixed testCompile and testApi deprecations

### DIFF
--- a/rules.gradle
+++ b/rules.gradle
@@ -26,9 +26,9 @@ dependencies {
 // Check if the android plugin version supports unit testing.
 if (configurations.findByName("testCompile")) {
   dependencies {
-      testCompile "junit:junit:4.12"
-      testCompile "org.hamcrest:hamcrest-library:1.3"
-      testCompile "org.mockito:mockito-core:2.19.0"
-      testCompile "org.robolectric:robolectric:3.4.2"
+      testImplementation "junit:junit:4.12"
+      testImplementation "org.hamcrest:hamcrest-library:1.3"
+      testImplementation "org.mockito:mockito-core:2.19.0"
+      testImplementation "org.robolectric:robolectric:3.4.2"
   }
 }

--- a/rules.gradle
+++ b/rules.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 // Check if the android plugin version supports unit testing.
-if (configurations.findByName("testCompile")) {
+if (configurations.findByName("testImplementation")) {
   dependencies {
       testImplementation "junit:junit:4.12"
       testImplementation "org.hamcrest:hamcrest-library:1.3"


### PR DESCRIPTION
Fixed testCompile and testApi deprecations, by changing to testImplementation. Got rid of warning that compile was obsolete, and has been replaced by implementation.