### PR TITLE
Implementations for remaining async cache methods (initialize, invalidate, remove)

### DIFF
--- a/src/main/java/com/android/volley/AsyncCache.java
+++ b/src/main/java/com/android/volley/AsyncCache.java
@@ -24,12 +24,44 @@ public abstract class AsyncCache {
      */
     public abstract void get(String key, OnGetCompleteCallback callback);
 
-    public interface OnPutCompleteCallback {
-        /** Invoked when the put to the cache is complete */
-        void onPutComplete();
+    public interface OnCompleteCallback {
+        /** Invoked when the operation on the cache is complete */
+        void onComplete();
     }
 
-    public abstract void put(String key, Cache.Entry entry, OnPutCompleteCallback callback);
+    /**
+     * Puts an entry into the cache and then calls {@link OnCompleteCallback#onComplete} when it is
+     * finished.
+     *
+     * @param key Cache key
+     * @param callback Callback that will be notified when the information has been retrieved
+     */
+    public abstract void put(String key, Cache.Entry entry, OnCompleteCallback callback);
 
-    // TODO(#181): Implement the rest.
+    /**
+     * Initializes the asynchronous cache and then calls {@link OnCompleteCallback#onComplete} when
+     * it is finished.
+     *
+     * @param callback Callback that will be notified when the cache has been initialized
+     */
+    public abstract void initialize(OnCompleteCallback callback);
+
+    /**
+     * Either fully or soft expires an entry in the cache, then calls {@link
+     * OnCompleteCallback#onComplete} function.
+     *
+     * @param key Cache key,
+     * @param fullExpire True to fully expire the entry, false to soft expire
+     * @param callback Callback that will be notified when the entry has been invalidated
+     */
+    public abstract void invalidate(String key, boolean fullExpire, OnCompleteCallback callback);
+
+    /**
+     * Removes an entry from the cache and calls {@link OnCompleteCallback#onComplete} function when
+     * it's finished
+     *
+     * @param key Cache key
+     * @param callback Callback that will be notified when the information has been retrieved
+     */
+    public abstract void remove(String key, OnCompleteCallback callback);
 }

--- a/src/main/java/com/android/volley/AsyncCache.java
+++ b/src/main/java/com/android/volley/AsyncCache.java
@@ -25,6 +25,7 @@ public abstract class AsyncCache {
     public abstract void get(String key, OnGetCompleteCallback callback);
 
     public interface OnPutCompleteCallback {
+        /** Invoked when the put to the cache is complete */
         void onPutComplete();
     }
 

--- a/src/main/java/com/android/volley/AsyncCache.java
+++ b/src/main/java/com/android/volley/AsyncCache.java
@@ -24,5 +24,11 @@ public abstract class AsyncCache {
      */
     public abstract void get(String key, OnGetCompleteCallback callback);
 
+    public interface OnPutCompleteCallback {
+        void onPutComplete();
+    }
+
+    public abstract void put(String key, Cache.Entry entry, OnPutCompleteCallback callback);
+
     // TODO(#181): Implement the rest.
 }

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -16,6 +16,9 @@ class CacheHeader {
     /** Magic number for current version of cache file format. */
     private static final int CACHE_MAGIC = 0x20150306;
 
+    /** Bits required to write 4 longs and 3 ints */
+    private static final int HEADER_SIZE = 44;
+
     /**
      * The size of the data identified by this CacheHeader on disk (both header and data).
      *
@@ -160,16 +163,16 @@ class CacheHeader {
 
     /** Gets the size of the header in bytes */
     int getHeaderSize() throws IOException {
-        int x = 44; // 4 longs, 3 ints
+        int size = 0;
         try {
-            x += key.getBytes("UTF8").length;
+            size += key.getBytes("UTF8").length;
             if (etag != null) {
-                x += etag.getBytes("UTF8").length;
+                size += etag.getBytes("UTF8").length;
             }
         } catch (UnsupportedEncodingException e) {
-            VolleyLog.e(e.toString());
+            VolleyLog.e(e, "UTF-8 is unsupported");
         }
-        x += DiskBasedCacheUtility.headerListSize(allResponseHeaders);
-        return x;
+        size += DiskBasedCacheUtility.headerListSize(allResponseHeaders);
+        return size + HEADER_SIZE;
     }
 }

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -6,6 +6,8 @@ import com.android.volley.Header;
 import com.android.volley.VolleyLog;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
@@ -142,5 +144,30 @@ class CacheHeader {
             VolleyLog.d("%s", e.toString());
             return false;
         }
+    }
+
+    void writeHeader(ByteBuffer buffer) throws IOException {
+        buffer.putInt(CACHE_MAGIC);
+        DiskBasedCacheUtility.writeString(buffer, key);
+        DiskBasedCacheUtility.writeString(buffer, etag);
+        buffer.putLong(serverDate);
+        buffer.putLong(lastModified);
+        buffer.putLong(ttl);
+        buffer.putLong(softTtl);
+        DiskBasedCacheUtility.writeHeaderList(allResponseHeaders, buffer);
+    }
+
+    int getHeaderSize() throws IOException {
+        int x = 36;
+        try {
+            x += key.getBytes("UTF8").length;
+            if (etag != null) {
+                x += etag.getBytes("UTF8").length;
+            }
+        } catch (UnsupportedEncodingException e) {
+            VolleyLog.e(e.toString());
+        }
+        x += DiskBasedCacheUtility.headerListSize(allResponseHeaders);
+        return x;
     }
 }

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -198,7 +198,7 @@ class CacheHeader {
             size += key.getBytes("UTF8").length;
             if (etag != null) {
                 size += etag.getBytes("UTF8").length;
-            }
+            
         } catch (UnsupportedEncodingException e) {
             VolleyLog.e(e, "UTF-8 is unsupported");
         }

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -146,6 +146,7 @@ class CacheHeader {
         }
     }
 
+    /** Writes the contents of this CacheHeader to the specified ByteBuffer. */
     void writeHeader(ByteBuffer buffer) throws IOException {
         buffer.putInt(CACHE_MAGIC);
         DiskBasedCacheUtility.writeString(buffer, key);
@@ -157,8 +158,9 @@ class CacheHeader {
         DiskBasedCacheUtility.writeHeaderList(allResponseHeaders, buffer);
     }
 
+    /** Gets the size of the header in bytes */
     int getHeaderSize() throws IOException {
-        int x = 36;
+        int x = 44; //4 longs, 3 ints
         try {
             x += key.getBytes("UTF8").length;
             if (etag != null) {

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -160,7 +160,7 @@ class CacheHeader {
 
     /** Gets the size of the header in bytes */
     int getHeaderSize() throws IOException {
-        int x = 44; //4 longs, 3 ints
+        int x = 44; // 4 longs, 3 ints
         try {
             x += key.getBytes("UTF8").length;
             if (etag != null) {

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -96,6 +96,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
         }
     }
 
+    /** Puts the cache entry with a specified key into the cache. */
     @Override
     public void put(final String key, Cache.Entry entry, final OnPutCompleteCallback callback) {
         // If adding this entry would trigger a prune, but pruning would cause the new entry to be
@@ -126,12 +127,15 @@ public class DiskBasedAsyncCache extends AsyncCache {
                         @Override
                         public void completed(Integer integer, Void aVoid) {
                             header.size = file.length();
-                            DiskBasedCacheUtility.putEntry(key, header, mTotalSize, mEntries);
-                            DiskBasedCacheUtility.pruneIfNeeded(
-                                    mTotalSize,
-                                    mMaxCacheSizeInBytes,
-                                    mEntries,
-                                    mRootDirectorySupplier);
+                            mTotalSize =
+                                    DiskBasedCacheUtility.putEntry(
+                                            key, header, mTotalSize, mEntries);
+                            mTotalSize =
+                                    DiskBasedCacheUtility.pruneIfNeeded(
+                                            mTotalSize,
+                                            mMaxCacheSizeInBytes,
+                                            mEntries,
+                                            mRootDirectorySupplier);
                         }
 
                         @Override

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -103,8 +103,8 @@ public class DiskBasedAsyncCache extends AsyncCache {
         // deleted, then skip writing the entry in the first place, as this is just churn.
         // Note that we don't include the cache header overhead in this calculation for simplicity,
         // so putting entries which are just below the threshold may still cause this churn.
-        if (DiskBasedCacheUtility.checkPrune(mTotalSize, entry.data.length, mMaxCacheSizeInBytes)
-                && DiskBasedCacheUtility.checkWouldDelete(
+        if (DiskBasedCacheUtility.wouldExceedCacheSize(mTotalSize + entry.data.length, mMaxCacheSizeInBytes)
+                && DiskBasedCacheUtility.isDataTooLarge(
                         entry.data.length, mMaxCacheSizeInBytes)) {
             return;
         }

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -120,9 +120,9 @@ public class DiskBasedAsyncCache extends AsyncCache {
             header.writeHeader(buffer);
             buffer.put(entry.data);
             afc.write(
-                    buffer,
-                    0,
-                    null,
+                    /* source= */ buffer,
+                    /* position= */0,
+                    /* attachment= */null,
                     new CompletionHandler<Integer, Void>() {
                         @Override
                         public void completed(Integer integer, Void aVoid) {
@@ -136,6 +136,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
                                             mMaxCacheSizeInBytes,
                                             mEntries,
                                             mRootDirectorySupplier);
+                            callback.onPutComplete();
                         }
 
                         @Override

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -103,9 +103,9 @@ public class DiskBasedAsyncCache extends AsyncCache {
         // deleted, then skip writing the entry in the first place, as this is just churn.
         // Note that we don't include the cache header overhead in this calculation for simplicity,
         // so putting entries which are just below the threshold may still cause this churn.
-        if (DiskBasedCacheUtility.wouldExceedCacheSize(mTotalSize + entry.data.length, mMaxCacheSizeInBytes)
-                && DiskBasedCacheUtility.isDataTooLarge(
-                        entry.data.length, mMaxCacheSizeInBytes)) {
+        if (DiskBasedCacheUtility.wouldExceedCacheSize(
+                        mTotalSize + entry.data.length, mMaxCacheSizeInBytes)
+                && DiskBasedCacheUtility.isDataTooLarge(entry.data.length, mMaxCacheSizeInBytes)) {
             return;
         }
 

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -14,10 +14,8 @@ import java.nio.channels.CompletionHandler;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
  * AsyncCache implementation that uses Java NIO's AsynchronousFileChannel to perform asynchronous
@@ -179,22 +177,6 @@ public class DiskBasedAsyncCache extends AsyncCache {
             callback.onComplete();
             return;
         }
-        Arrays.asList(files).parallelStream().forEach(new Consumer<File>() {
-              @Override
-              public void accept(File file) {
-                  try (AsynchronousFileChannel afc =
-                               AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.READ)) {
-                      long entrySize = file.length();
-                      CacheHeader entry = CacheHeader.readHeader(afc);
-                      entry.size = entrySize;
-                      DiskBasedCacheUtility.putEntry(entry.key, entry, mTotalSize, mEntries);
-                  } catch (IOException e) {
-                      //noinspection ResultOfMethodCallIgnored
-                      file.delete();
-                  }
-              }
-          }
-        );
         for (File file : files) {
             try (AsynchronousFileChannel afc =
                     AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.READ)) {

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -121,8 +121,8 @@ public class DiskBasedAsyncCache extends AsyncCache {
             buffer.put(entry.data);
             afc.write(
                     /* source= */ buffer,
-                    /* position= */0,
-                    /* attachment= */null,
+                    /* position= */ 0,
+                    /* attachment= */ null,
                     new CompletionHandler<Integer, Void>() {
                         @Override
                         public void completed(Integer integer, Void aVoid) {

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -222,9 +222,9 @@ public class DiskBasedCache implements Cache {
         // deleted, then skip writing the entry in the first place, as this is just churn.
         // Note that we don't include the cache header overhead in this calculation for simplicity,
         // so putting entries which are just below the threshold may still cause this churn.
-        if (mTotalSize + entry.data.length > mMaxCacheSizeInBytes
-                && entry.data.length
-                        > mMaxCacheSizeInBytes * DiskBasedCacheUtility.HYSTERESIS_FACTOR) {
+        if (DiskBasedCacheUtility.checkPrune(mTotalSize, entry.data.length, mMaxCacheSizeInBytes)
+                && DiskBasedCacheUtility.checkWouldDelete(
+                        entry.data.length, mMaxCacheSizeInBytes)) {
             return;
         }
         File file = DiskBasedCacheUtility.getFileForKey(key, mRootDirectorySupplier);

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -222,8 +222,8 @@ public class DiskBasedCache implements Cache {
         // deleted, then skip writing the entry in the first place, as this is just churn.
         // Note that we don't include the cache header overhead in this calculation for simplicity,
         // so putting entries which are just below the threshold may still cause this churn.
-        if (DiskBasedCacheUtility.checkPrune(mTotalSize, entry.data.length, mMaxCacheSizeInBytes)
-                && DiskBasedCacheUtility.checkWouldDelete(
+        if (DiskBasedCacheUtility.wouldExceedCacheSize(mTotalSize + entry.data.length, mMaxCacheSizeInBytes)
+                && DiskBasedCacheUtility.isDataTooLarge(
                         entry.data.length, mMaxCacheSizeInBytes)) {
             return;
         }

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCache.java
@@ -222,9 +222,9 @@ public class DiskBasedCache implements Cache {
         // deleted, then skip writing the entry in the first place, as this is just churn.
         // Note that we don't include the cache header overhead in this calculation for simplicity,
         // so putting entries which are just below the threshold may still cause this churn.
-        if (DiskBasedCacheUtility.wouldExceedCacheSize(mTotalSize + entry.data.length, mMaxCacheSizeInBytes)
-                && DiskBasedCacheUtility.isDataTooLarge(
-                        entry.data.length, mMaxCacheSizeInBytes)) {
+        if (DiskBasedCacheUtility.wouldExceedCacheSize(
+                        mTotalSize + entry.data.length, mMaxCacheSizeInBytes)
+                && DiskBasedCacheUtility.isDataTooLarge(entry.data.length, mMaxCacheSizeInBytes)) {
             return;
         }
         File file = DiskBasedCacheUtility.getFileForKey(key, mRootDirectorySupplier);

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
@@ -143,7 +143,7 @@ class DiskBasedCacheUtility {
     }
 
     static void writeInt(OutputStream os, int n) throws IOException {
-        os.write((n >> 0) & 0xff);
+        os.write(n & 0xff);
         os.write((n >> 8) & 0xff);
         os.write((n >> 16) & 0xff);
         os.write((n >> 24) & 0xff);
@@ -151,7 +151,7 @@ class DiskBasedCacheUtility {
 
     static int readInt(InputStream is) throws IOException {
         int n = 0;
-        n |= (read(is) << 0);
+        n |= read(is);
         n |= (read(is) << 8);
         n |= (read(is) << 16);
         n |= (read(is) << 24);
@@ -159,7 +159,7 @@ class DiskBasedCacheUtility {
     }
 
     static void writeLong(OutputStream os, long n) throws IOException {
-        os.write((byte) (n >>> 0));
+        os.write((byte) n);
         os.write((byte) (n >>> 8));
         os.write((byte) (n >>> 16));
         os.write((byte) (n >>> 24));
@@ -171,7 +171,7 @@ class DiskBasedCacheUtility {
 
     static long readLong(InputStream is) throws IOException {
         long n = 0;
-        n |= ((read(is) & 0xFFL) << 0);
+        n |= (read(is) & 0xFFL);
         n |= ((read(is) & 0xFFL) << 8);
         n |= ((read(is) & 0xFFL) << 16);
         n |= ((read(is) & 0xFFL) << 24);

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
@@ -48,12 +48,12 @@ class DiskBasedCacheUtility {
         return new File(rootDirectorySupplier.get(), getFilenameForKey(key));
     }
 
-    static boolean checkPrune(long totalSize, int dataLength, int maxCacheSize) {
-        return (totalSize + dataLength > maxCacheSize);
+    static boolean wouldExceedCacheSize(long newTotalSize, int maxCacheSize) {
+        return (newTotalSize >= maxCacheSize);
     }
 
-    static boolean checkWouldDelete(int dataLength, int maxCacheSize) {
-        return dataLength > maxCacheSize * HYSTERESIS_FACTOR;
+    static boolean isDataTooLarge(int dataLength, int maxCacheSize) {
+        return dataLength >= maxCacheSize * HYSTERESIS_FACTOR;
     }
 
     /**
@@ -71,7 +71,7 @@ class DiskBasedCacheUtility {
             int maxCacheSizeInBytes,
             Map<String, CacheHeader> entries,
             FileSupplier rootDirectorySupplier) {
-        if (totalSize < maxCacheSizeInBytes) {
+        if (!wouldExceedCacheSize(totalSize, maxCacheSizeInBytes)) {
             return totalSize;
         }
         if (VolleyLog.DEBUG) {
@@ -97,7 +97,7 @@ class DiskBasedCacheUtility {
             iterator.remove();
             prunedFiles++;
 
-            if (totalSize < maxCacheSizeInBytes * HYSTERESIS_FACTOR) {
+            if (!isDataTooLarge((int) totalSize, maxCacheSizeInBytes)) {
                 break;
             }
         }

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
@@ -47,14 +47,14 @@ class DiskBasedCacheUtility {
         return new File(rootDirectorySupplier.get(), getFilenameForKey(key));
     }
 
-    /** Prunes the .
+    /**
+     * Prunes the .
      *
      * @param totalSize The total size of the cache.
      * @param maxCacheSizeInBytes Maximum size of the cache.
      * @param entries Map of the entries in the cache.
      * @param rootDirectorySupplier The supplier for the root directory to use for the cache.
      * @return A long to update the totalSize.
-     *
      */
     static long pruneIfNeeded(
             long totalSize,

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
@@ -188,14 +188,15 @@ class DiskBasedCacheUtility {
         os.write(b, 0, b.length);
     }
 
-    static int writeString(ByteBuffer buffer, String s) throws IOException {
+    static void writeString(ByteBuffer buffer, String s) throws IOException {
+        // if the string is null, put the length as 0.
         if (s == null) {
-            return 0;
+            buffer.putLong(0);
+            return;
         }
         byte[] b = s.getBytes("UTF-8");
         buffer.putLong(b.length);
         buffer.put(b);
-        return b.length + 8;
     }
 
     static String readString(CountingInputStream cis) throws IOException {

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
@@ -49,11 +49,11 @@ class DiskBasedCacheUtility {
     }
 
     static boolean wouldExceedCacheSize(long newTotalSize, int maxCacheSize) {
-        return (newTotalSize >= maxCacheSize);
+        return (newTotalSize > maxCacheSize);
     }
 
     static boolean isDataTooLarge(int dataLength, int maxCacheSize) {
-        return dataLength >= maxCacheSize * HYSTERESIS_FACTOR;
+        return dataLength > maxCacheSize * HYSTERESIS_FACTOR;
     }
 
     /**
@@ -71,7 +71,7 @@ class DiskBasedCacheUtility {
             int maxCacheSizeInBytes,
             Map<String, CacheHeader> entries,
             FileSupplier rootDirectorySupplier) {
-        if (!wouldExceedCacheSize(totalSize, maxCacheSizeInBytes)) {
+        if (!wouldExceedCacheSize(totalSize + 1, maxCacheSizeInBytes)) {
             return totalSize;
         }
         if (VolleyLog.DEBUG) {

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
@@ -43,11 +43,19 @@ class DiskBasedCacheUtility {
     }
 
     /** Returns a file object for the given cache key. */
-    static File getFileForKey(String key, FileSupplier rootDirectorySupplier) {
+    public static File getFileForKey(String key, FileSupplier rootDirectorySupplier) {
         return new File(rootDirectorySupplier.get(), getFilenameForKey(key));
     }
 
-    /** Prunes the cache to fit the maximum size. */
+    /** Prunes the .
+     *
+     * @param totalSize The total size of the cache.
+     * @param maxCacheSizeInBytes Maximum size of the cache.
+     * @param entries Map of the entries in the cache.
+     * @param rootDirectorySupplier The supplier for the root directory to use for the cache.
+     * @return A long to update the totalSize.
+     *
+     */
     static long pruneIfNeeded(
             long totalSize,
             int maxCacheSizeInBytes,
@@ -97,8 +105,11 @@ class DiskBasedCacheUtility {
      *
      * @param key The key to identify the entry by.
      * @param entry The entry to cache.
+     * @param totalSize The total size of the cache.
+     * @param entries Map of the entries in the cache.
+     * @return A long to update the total size.
      */
-    static void putEntry(
+    static long putEntry(
             String key, CacheHeader entry, long totalSize, Map<String, CacheHeader> entries) {
         if (!entries.containsKey(key)) {
             totalSize += entry.size;
@@ -107,6 +118,7 @@ class DiskBasedCacheUtility {
             totalSize += (entry.size - oldEntry.size);
         }
         entries.put(key, entry);
+        return totalSize;
     }
 
     /*
@@ -204,18 +216,15 @@ class DiskBasedCacheUtility {
         }
     }
 
-    static int writeHeaderList(List<Header> headers, ByteBuffer buffer) throws IOException {
+    static void writeHeaderList(List<Header> headers, ByteBuffer buffer) throws IOException {
         if (headers != null) {
-            int bytes = 4;
             buffer.putInt(headers.size());
             for (Header header : headers) {
-                bytes += writeString(buffer, header.getName());
-                bytes += writeString(buffer, header.getValue());
+                writeString(buffer, header.getName());
+                writeString(buffer, header.getValue());
             }
-            return bytes;
         } else {
             buffer.putInt(0);
-            return 4;
         }
     }
 

--- a/src/main/java/com/android/volley/toolbox/Volley.java
+++ b/src/main/java/com/android/volley/toolbox/Volley.java
@@ -89,8 +89,8 @@ public class Volley {
         final Context appContext = context.getApplicationContext();
         // Use a lazy supplier for the cache directory so that newRequestQueue() can be called on
         // main thread without causing strict mode violation.
-        DiskBasedCache.FileSupplier cacheSupplier =
-                new DiskBasedCache.FileSupplier() {
+        DiskBasedCacheUtility.FileSupplier cacheSupplier =
+                new DiskBasedCacheUtility.FileSupplier() {
                     private File cacheDir = null;
 
                     @Override

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -478,10 +478,11 @@ public class DiskBasedCacheTest {
         // Catch-all test to find API-breaking changes.
         assertNotNull(DiskBasedCache.class.getConstructor(File.class, int.class));
         assertNotNull(
-                DiskBasedCache.class.getConstructor(DiskBasedCache.FileSupplier.class, int.class));
+                DiskBasedCache.class.getConstructor(
+                        DiskBasedCacheUtility.FileSupplier.class, int.class));
         assertNotNull(DiskBasedCache.class.getConstructor(File.class));
-        assertNotNull(DiskBasedCache.class.getConstructor(DiskBasedCache.FileSupplier.class));
-
+        assertNotNull(
+                DiskBasedCache.class.getConstructor(DiskBasedCacheUtility.FileSupplier.class));
         assertNotNull(DiskBasedCache.class.getMethod("getFileForKey", String.class));
     }
 


### PR DESCRIPTION
Implemented the remaining methods for this class. This involved adding read methods that took in an AsyncFileChannel. I used a Future for these operations in place of a CompletionHandler, as that seemed much simpler in this case. Consolidated the callback interface for put, init, invalidate, and remove, since they all did the same thing. Can change this back to them each having their own if there are any benefits to that.

Initialize still has a loop over a files array, but couldn't figure out how to do that asynchronously since our map is not thread safe. 