### PR TITLE
Implementations for rest of AsyncCache, tests for cache methods, still no thread safety yet

### DIFF
--- a/src/main/java/com/android/volley/AsyncCache.java
+++ b/src/main/java/com/android/volley/AsyncCache.java
@@ -39,14 +39,21 @@ public abstract class AsyncCache {
      */
     public abstract void put(String key, Cache.Entry entry, OnCompleteCallback callback);
 
-    /** Clears the cache. Deletes all cached files from disk. */
+    /**
+     * Clears the cache. Deletes all cached files from disk. Calls {@link
+     * OnCompleteCallback#onComplete} after the operation is finished.
+     */
     public abstract void clear(OnCompleteCallback callback);
 
-    /** Initializes the cache. */
+    /**
+     * Initializes the cache and calls {@link OnCompleteCallback#onComplete} after the operation is
+     * finished.
+     */
     public abstract void initialize(OnCompleteCallback callback);
 
     /**
-     * Invalidates an entry in the cache.
+     * Invalidates an entry in the cache and calls {@link OnCompleteCallback#onComplete} after the
+     * operation is finished.
      *
      * @param key Cache key
      * @param fullExpire True to fully expire the entry, false to soft expire

--- a/src/main/java/com/android/volley/AsyncCache.java
+++ b/src/main/java/com/android/volley/AsyncCache.java
@@ -24,49 +24,50 @@ public abstract class AsyncCache {
      */
     public abstract void get(String key, OnGetCompleteCallback callback);
 
-    public interface OnCompleteCallback {
+    public interface OnWriteCompleteCallback {
         /** Invoked when the cache operation is complete */
-        void onComplete();
+        void onWriteComplete();
     }
 
     /**
-     * Writes a {@link Cache.Entry} to the cache, and calls {@link OnCompleteCallback#onComplete}
-     * after the operation is finished.
+     * Writes a {@link Cache.Entry} to the cache, and calls {@link
+     * OnWriteCompleteCallback#onWriteComplete} after the operation is finished.
      *
      * @param key Cache key
      * @param entry The entry to be written to the cache
      * @param callback Callback that will be notified when the information has been written
      */
-    public abstract void put(String key, Cache.Entry entry, OnCompleteCallback callback);
+    public abstract void put(String key, Cache.Entry entry, OnWriteCompleteCallback callback);
 
     /**
      * Clears the cache. Deletes all cached files from disk. Calls {@link
-     * OnCompleteCallback#onComplete} after the operation is finished.
+     * OnWriteCompleteCallback#onWriteComplete} after the operation is finished.
      */
-    public abstract void clear(OnCompleteCallback callback);
+    public abstract void clear(OnWriteCompleteCallback callback);
 
     /**
-     * Initializes the cache and calls {@link OnCompleteCallback#onComplete} after the operation is
-     * finished.
-     */
-    public abstract void initialize(OnCompleteCallback callback);
-
-    /**
-     * Invalidates an entry in the cache and calls {@link OnCompleteCallback#onComplete} after the
+     * Initializes the cache and calls {@link OnWriteCompleteCallback#onWriteComplete} after the
      * operation is finished.
+     */
+    public abstract void initialize(OnWriteCompleteCallback callback);
+
+    /**
+     * Invalidates an entry in the cache and calls {@link OnWriteCompleteCallback#onWriteComplete}
+     * after the operation is finished.
      *
      * @param key Cache key
      * @param fullExpire True to fully expire the entry, false to soft expire
      * @param callback Callback that's invoked once the entry has been invalidated
      */
-    public abstract void invalidate(String key, boolean fullExpire, OnCompleteCallback callback);
+    public abstract void invalidate(
+            String key, boolean fullExpire, OnWriteCompleteCallback callback);
 
     /**
-     * Removes a {@link Cache.Entry} from the cache, and calls {@link OnCompleteCallback#onComplete}
-     * after the operation is finished.
+     * Removes a {@link Cache.Entry} from the cache, and calls {@link
+     * OnWriteCompleteCallback#onWriteComplete} after the operation is finished.
      *
      * @param key Cache key
      * @param callback Callback that's invoked once the entry has been removed
      */
-    public abstract void remove(String key, OnCompleteCallback callback);
+    public abstract void remove(String key, OnWriteCompleteCallback callback);
 }

--- a/src/main/java/com/android/volley/AsyncCache.java
+++ b/src/main/java/com/android/volley/AsyncCache.java
@@ -24,20 +24,42 @@ public abstract class AsyncCache {
      */
     public abstract void get(String key, OnGetCompleteCallback callback);
 
-    public interface OnPutCompleteCallback {
-        /** Invoked when the put to the cache is complete. */
-        void onPutComplete();
+    public interface OnCompleteCallback {
+        /** Invoked when the cache operation is complete */
+        void onComplete();
     }
 
     /**
-     * Writes a {@link Cache.Entry} to the cache, and calls {@link
-     * OnPutCompleteCallback#onPutComplete} after the operation is finished.
+     * Writes a {@link Cache.Entry} to the cache, and calls {@link OnCompleteCallback#onComplete}
+     * after the operation is finished.
      *
      * @param key Cache key
      * @param entry The entry to be written to the cache
      * @param callback Callback that will be notified when the information has been written
      */
-    public abstract void put(String key, Cache.Entry entry, OnPutCompleteCallback callback);
+    public abstract void put(String key, Cache.Entry entry, OnCompleteCallback callback);
 
-    // TODO(#181): Implement the rest.
+    /** Clears the cache. Deletes all cached files from disk. */
+    public abstract void clear(OnCompleteCallback callback);
+
+    /** Initializes the cache. */
+    public abstract void initialize(OnCompleteCallback callback);
+
+    /**
+     * Invalidates an entry in the cache.
+     *
+     * @param key Cache key
+     * @param fullExpire True to fully expire the entry, false to soft expire
+     * @param callback Callback that's invoked once the entry has been invalidated
+     */
+    public abstract void invalidate(String key, boolean fullExpire, OnCompleteCallback callback);
+
+    /**
+     * Removes a {@link Cache.Entry} from the cache, and calls {@link OnCompleteCallback#onComplete}
+     * after the operation is finished.
+     *
+     * @param key Cache key
+     * @param callback Callback that's invoked once the entry has been removed
+     */
+    public abstract void remove(String key, OnCompleteCallback callback);
 }

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -1,19 +1,14 @@
 package com.android.volley.toolbox;
 
-import android.os.Build;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import com.android.volley.Cache;
 import com.android.volley.Header;
 import com.android.volley.VolleyLog;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.AsynchronousFileChannel;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 /** Handles holding onto the cache headers for an entry. */
 class CacheHeader {
@@ -116,43 +111,6 @@ class CacheHeader {
         long ttl = DiskBasedCacheUtility.readLong(is);
         long softTtl = DiskBasedCacheUtility.readLong(is);
         List<Header> allResponseHeaders = DiskBasedCacheUtility.readHeaderList(is);
-        return new CacheHeader(
-                key, etag, serverDate, lastModified, ttl, softTtl, allResponseHeaders);
-    }
-
-    /**
-     * Reads the header from a AsynchronousFileChannel and returns a CacheHeader object.
-     *
-     * @param afc File channel to read from.
-     * @param size Size of the cache header.
-     * @throws IOException if fails to read header
-     */
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    static CacheHeader readHeader(final AsynchronousFileChannel afc, int size) throws IOException {
-        final ByteBuffer buffer = ByteBuffer.allocate(size);
-        Future<Integer> fillBuffer = afc.read(buffer, 0);
-        try {
-            fillBuffer.get();
-        } catch (ExecutionException e) {
-            VolleyLog.e(e.toString(), "ExecutionException thrown");
-            throw new IOException(e);
-        } catch (InterruptedException e) {
-            VolleyLog.e(e.toString(), "InterruptedException caught");
-            Thread.currentThread().interrupt();
-        }
-        buffer.flip();
-        int magic = buffer.getInt();
-        if (magic != CACHE_MAGIC) {
-            // don't bother deleting, it'll get pruned eventually
-            throw new IOException();
-        }
-        String key = DiskBasedCacheUtility.readString(buffer);
-        String etag = DiskBasedCacheUtility.readString(buffer);
-        long serverDate = buffer.getLong();
-        long lastModified = buffer.getLong();
-        long ttl = buffer.getLong();
-        long softTtl = buffer.getLong();
-        List<Header> allResponseHeaders = DiskBasedCacheUtility.readHeaderList(buffer);
         return new CacheHeader(
                 key, etag, serverDate, lastModified, ttl, softTtl, allResponseHeaders);
     }

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -157,6 +157,36 @@ class CacheHeader {
                 key, etag, serverDate, lastModified, ttl, softTtl, allResponseHeaders);
     }
 
+    /**
+     * Reads the header from a AsynchronousFileChannel and returns a CacheHeader object.
+     *
+     * @param buffer Buffer to get header info from.
+     * @throws IOException if fails to read header
+     */
+    @Nullable
+    static CacheHeader readHeader(final ByteBuffer buffer) {
+        try {
+            buffer.flip();
+            int magic = buffer.getInt();
+            if (magic != CACHE_MAGIC) {
+                // don't bother deleting, it'll get pruned eventually
+                return null;
+            }
+            String key = DiskBasedCacheUtility.readString(buffer);
+            String etag = DiskBasedCacheUtility.readString(buffer);
+            long serverDate = buffer.getLong();
+            long lastModified = buffer.getLong();
+            long ttl = buffer.getLong();
+            long softTtl = buffer.getLong();
+            List<Header> allResponseHeaders = DiskBasedCacheUtility.readHeaderList(buffer);
+            return new CacheHeader(
+                    key, etag, serverDate, lastModified, ttl, softTtl, allResponseHeaders);
+        } catch (IOException e) {
+            VolleyLog.d(e.toString(), "Failed to read CacheHeader");
+            return null;
+        }
+    }
+
     /** Creates a cache entry for the specified data. */
     Cache.Entry toCacheEntry(byte[] data) {
         Cache.Entry e = new Cache.Entry();

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -128,6 +128,7 @@ class CacheHeader {
      * @throws IOException if fails to read header
      */
     @RequiresApi(api = Build.VERSION_CODES.O)
+    @Nullable
     static CacheHeader readHeader(final AsynchronousFileChannel afc, int size) throws IOException {
         final ByteBuffer buffer = ByteBuffer.allocate(size);
         Future<Integer> fillBuffer = afc.read(buffer, 0);
@@ -149,7 +150,7 @@ class CacheHeader {
             return new CacheHeader(
                     key, etag, serverDate, lastModified, ttl, softTtl, allResponseHeaders);
         } catch (ExecutionException | InterruptedException e) {
-            throw new IOException(e);
+            return null;
         }
     }
 

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -137,9 +137,8 @@ class CacheHeader {
             VolleyLog.e(e.toString(), "ExecutionException thrown");
             throw new IOException(e);
         } catch (InterruptedException e) {
-            VolleyLog.e(e.toString(), "InterruptedException thrown");
+            VolleyLog.e(e.toString(), "InterruptedException caught");
             Thread.currentThread().interrupt();
-            throw new IOException(e);
         }
         buffer.flip();
         int magic = buffer.getInt();

--- a/src/main/java/com/android/volley/toolbox/CacheHeader.java
+++ b/src/main/java/com/android/volley/toolbox/CacheHeader.java
@@ -148,10 +148,8 @@ class CacheHeader {
             List<Header> allResponseHeaders = DiskBasedCacheUtility.readHeaderList(buffer);
             return new CacheHeader(
                     key, etag, serverDate, lastModified, ttl, softTtl, allResponseHeaders);
-        } catch (ExecutionException e) {
-            throw new IOException();
-        } catch (InterruptedException e) {
-            throw new IOException();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new IOException(e);
         }
     }
 

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -75,19 +75,11 @@ public class DiskBasedAsyncCache extends AsyncCache {
             channel = afc;
             int headerSize = entry.getHeaderSize();
             CacheHeader entryOnDisk = CacheHeader.readHeader(afc, headerSize);
-            if (entryOnDisk == null || !TextUtils.equals(key, entryOnDisk.key)) {
-                if (entryOnDisk == null) {
-                    // ExecutionException/InterruptedException was thrown while reading CacheHeader!
-                    VolleyLog.e(
-                            "%s: key=%s, exception was thrown while reading header",
-                            file.getAbsolutePath(), key);
-                } else {
-                    // File was shared by two keys and now holds data for a different entry!
-                    VolleyLog.d(
-                            "%s: key=%s, found=%s", file.getAbsolutePath(), key, entryOnDisk.key);
-                    // Remove key whose contents on disk have been replaced.
-                    mTotalSize = DiskBasedCacheUtility.removeEntry(key, mTotalSize, mEntries);
-                }
+            if (!TextUtils.equals(key, entryOnDisk.key)) {
+                // File was shared by two keys and now holds data for a different entry!
+                VolleyLog.d("%s: key=%s, found=%s", file.getAbsolutePath(), key, entryOnDisk.key);
+                // Remove key whose contents on disk have been replaced.
+                mTotalSize = DiskBasedCacheUtility.removeEntry(key, mTotalSize, mEntries);
                 closeChannel(afc, "failed read");
                 callback.onGetComplete(null);
                 return;
@@ -248,13 +240,8 @@ public class DiskBasedAsyncCache extends AsyncCache {
                 int entrySize = (int) file.length();
                 CacheHeader entry = CacheHeader.readHeader(afc, entrySize);
                 afc.close();
-                if (entry != null) {
-                    entry.size = entrySize;
-                    mTotalSize =
-                            DiskBasedCacheUtility.putEntry(entry.key, entry, mTotalSize, mEntries);
-                } else {
-                    deleteFile(file);
-                }
+                entry.size = entrySize;
+                mTotalSize = DiskBasedCacheUtility.putEntry(entry.key, entry, mTotalSize, mEntries);
             } catch (IOException e) {
                 closeChannel(afc, "IOException in initialize");
                 deleteFile(file);

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -118,14 +118,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
         } catch (IOException e) {
             VolleyLog.e(e, "Failed to read file %s", file.getAbsolutePath());
             closeChannel(channel, "IOException");
-            remove(
-                    key,
-                    new OnWriteCompleteCallback() {
-                        @Override
-                        public void onWriteComplete() {
-                            callback.onGetComplete(null);
-                        }
-                    });
+            removeDeleteAndCall(key, callback, file);
         }
     }
 

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -250,7 +250,8 @@ public class DiskBasedAsyncCache extends AsyncCache {
                 afc.close();
                 if (entry != null) {
                     entry.size = entrySize;
-                    mTotalSize = DiskBasedCacheUtility.putEntry(entry.key, entry, mTotalSize, mEntries);
+                    mTotalSize =
+                            DiskBasedCacheUtility.putEntry(entry.key, entry, mTotalSize, mEntries);
                 } else {
                     deleteFile(file);
                 }

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -78,8 +78,6 @@ public class DiskBasedAsyncCache extends AsyncCache {
             if (!TextUtils.equals(key, entryOnDisk.key)) {
                 // File was shared by two keys and now holds data for a different entry!
                 VolleyLog.d("%s: key=%s, found=%s", file.getAbsolutePath(), key, entryOnDisk.key);
-                System.out.println(
-                        file.getAbsolutePath() + " " + key + " entry on disk " + entryOnDisk.key);
                 // Remove key whose contents on disk have been replaced.
                 mTotalSize = DiskBasedCacheUtility.removeEntry(key, mTotalSize, mEntries);
                 callback.onGetComplete(null);
@@ -219,9 +217,14 @@ public class DiskBasedAsyncCache extends AsyncCache {
             if (!rootDirectory.mkdirs()) {
                 VolleyLog.e("Unable to create cache dir %s", rootDirectory.getAbsolutePath());
             }
+            callback.onComplete();
             return;
         }
         File[] files = rootDirectory.listFiles();
+        if (files == null) {
+            callback.onComplete();
+            return;
+        }
         for (File file : files) {
             Path path = file.toPath();
             AsynchronousFileChannel afc = null;
@@ -310,7 +313,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
         initializeIfRootDirectoryDeleted();
     }
 
-    /** Empty onCompleteCallback when no operation is needed in the callback */
+    /** Empty onCompleteCallback when no operation is needed in the callback. */
     private OnCompleteCallback emptyCallback =
             new OnCompleteCallback() {
                 @Override
@@ -319,7 +322,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
                 }
             };
 
-    /** Invokes get method, and returns a future with the cache entry for the specified key */
+    /** Invokes get method, and returns a future with the cache entry for the specified key. */
     private CompletableFuture<Cache.Entry> getFuture(String key) {
         final CompletableFuture<Cache.Entry> future = new CompletableFuture<>();
         get(
@@ -333,7 +336,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
         return future;
     }
 
-    /** Invokes put method, and returns a future that completes once put is finished */
+    /** Invokes put method, and returns a future that completes once put is finished. */
     private CompletableFuture<Void> putFuture(String key, Cache.Entry entry) {
         final CompletableFuture<Void> future = new CompletableFuture<>();
         put(

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -93,11 +93,10 @@ public class DiskBasedAsyncCache extends AsyncCache {
                             buffer.flip();
                             CacheHeader entryOnDisk = CacheHeader.readHeader(buffer);
                             if (entryOnDisk == null) {
-                                // IOException or RuntimeException was thrown while reading header!
+                                // BufferUnderflowException was thrown while reading header
                                 removeDeleteAndCall(key, callback, file);
                             } else if (!TextUtils.equals(key, entryOnDisk.key)) {
-                                // File was shared by two keys and now holds data for a different
-                                // entry!
+                                // File shared by two keys and holds data for a different entry!
                                 VolleyLog.d(
                                         "%s: key=%s, found=%s",
                                         file.getAbsolutePath(), key, entryOnDisk.key);
@@ -388,7 +387,13 @@ public class DiskBasedAsyncCache extends AsyncCache {
         }
     }
 
-    /** Removes the key, calls the callback. */
+    /**
+     * Deletes the file, removes the entry from the map, and calls OnGetComplete with a null value.
+     *
+     * @param key of the file to be removed.
+     * @param callback to be called after removing.
+     * @param file to be deleted.
+     */
     private void removeDeleteAndCall(String key, OnGetCompleteCallback callback, File file) {
         deleteFile(file);
         mTotalSize = DiskBasedCacheUtility.removeEntry(key, mTotalSize, mEntries);

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -389,7 +389,8 @@ public class DiskBasedAsyncCache extends AsyncCache {
      * @param callback to be called after removing.
      * @param file to be deleted.
      */
-    private void deleteFileAndInvokeCallback(String key, OnGetCompleteCallback callback, File file) {
+    private void deleteFileAndInvokeCallback(
+            String key, OnGetCompleteCallback callback, File file) {
         deleteFile(file);
         mTotalSize = DiskBasedCacheUtility.removeEntry(key, mTotalSize, mEntries);
         callback.onGetComplete(null);

--- a/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedCacheUtility.java
@@ -291,8 +291,7 @@ class DiskBasedCacheUtility {
         if (size < 0) {
             throw new IOException("readHeaderList size=" + size);
         }
-        List<Header> result =
-                (size == 0) ? Collections.<Header>emptyList() : new ArrayList<Header>();
+        List<Header> result = new ArrayList<Header>();
         for (int i = 0; i < size; i++) {
             String name = readString(buffer);
             String value = readString(buffer);

--- a/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
@@ -260,9 +260,9 @@ public class DiskBasedAsyncCacheTest {
         operation.get();
         afc.close();
 
-        // key is gone, but file is still there
+        // key is gone, and file is deleted
         assertNull(getEntry("key").get());
-        assertThat(listCachedFiles(), is(arrayWithSize(1)));
+        assertThat(listCachedFiles(), is(arrayWithSize(0)));
 
         // Note: file is now a zombie because its key does not map to its name
     }

--- a/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
@@ -3,7 +3,6 @@ package com.android.volley.toolbox;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
@@ -82,7 +81,7 @@ public class DiskBasedAsyncCacheTest {
         putEntry("my-magical-key", entry).get();
 
         CacheTestUtils.assertThatEntriesAreEqual(getEntry("my-magical-key").get(), entry);
-        assertThat(getEntry("unknown-key").get(), is(nullValue()));
+        assertNull(getEntry("unknown-key").get());
     }
 
     @Test
@@ -92,7 +91,7 @@ public class DiskBasedAsyncCacheTest {
                         MAX_SIZE - CacheTestUtils.getEntrySizeOnDisk("oversize") + 1);
         putEntry("oversize", entry).get();
 
-        assertThat(getEntry("oversize").get(), is(nullValue()));
+        assertNull(getEntry("oversize").get());
     }
 
     @Test
@@ -118,7 +117,7 @@ public class DiskBasedAsyncCacheTest {
         entry = CacheTestUtils.randomData(0);
         putEntry("bit", entry).get();
 
-        assertThat(getEntry("maxsize").get(), is(nullValue()));
+        assertNull(getEntry("maxsize").get());
         CacheTestUtils.assertThatEntriesAreEqual(getEntry("bit").get(), entry);
     }
 
@@ -150,9 +149,9 @@ public class DiskBasedAsyncCacheTest {
 
         putEntry("max", entry).get();
 
-        assertThat(getEntry("entry1").get(), is(nullValue()));
-        assertThat(getEntry("entry2").get(), is(nullValue()));
-        assertThat(getEntry("entry3").get(), is(nullValue()));
+        assertNull(getEntry("entry1").get());
+        assertNull(getEntry("entry2").get());
+        assertNull(getEntry("entry3").get());
         CacheTestUtils.assertThatEntriesAreEqual(getEntry("max").get(), entry);
     }
 
@@ -185,10 +184,10 @@ public class DiskBasedAsyncCacheTest {
 
         putEntry("max", entry).get();
 
-        assertThat(getEntry("entry1").get(), is(nullValue()));
-        assertThat(getEntry("entry2").get(), is(nullValue()));
-        assertThat(getEntry("entry3").get(), is(nullValue()));
-        assertThat(getEntry("max").get(), is(nullValue()));
+        assertNull(getEntry("entry1").get());
+        assertNull(getEntry("entry2").get());
+        assertNull(getEntry("entry3").get());
+        assertNull(getEntry("max").get());
     }
 
     @Test
@@ -216,8 +215,8 @@ public class DiskBasedAsyncCacheTest {
 
         putEntry("entry4", entry4).get();
 
-        assertThat(getEntry("entry1").get(), is(nullValue()));
-        assertThat(getEntry("entry2").get(), is(nullValue()));
+        assertNull(getEntry("entry1").get());
+        assertNull(getEntry("entry2").get());
         CacheTestUtils.assertThatEntriesAreEqual(getEntry("entry3").get(), entry3);
         CacheTestUtils.assertThatEntriesAreEqual(getEntry("entry4").get(), entry4);
     }
@@ -235,7 +234,7 @@ public class DiskBasedAsyncCacheTest {
         FileOutputStream fos = new FileOutputStream(file);
         DiskBasedCacheUtility.writeInt(fos, 0);
         fos.close();
-        assertThat(getEntry("key").get(), is(nullValue()));
+        assertNull(getEntry("key").get());
         assertThat(listCachedFiles(), is(emptyArray())); // should this be??
     }
 
@@ -262,7 +261,7 @@ public class DiskBasedAsyncCacheTest {
         afc.close();
 
         // key is gone, but file is still there
-        assertThat(getEntry("key").get(), is(nullValue()));
+        assertNull(getEntry("key").get());
         assertThat(listCachedFiles(), is(arrayWithSize(1)));
 
         // Note: file is now a zombie because its key does not map to its name
@@ -276,7 +275,7 @@ public class DiskBasedAsyncCacheTest {
         CacheTestUtils.assertThatEntriesAreEqual(getEntry("key").get(), entry);
 
         removeEntry("key").get();
-        assertThat(getEntry("key").get(), is(nullValue()));
+        assertNull(getEntry("key").get());
         assertThat(listCachedFiles(), is(emptyArray()));
     }
 
@@ -288,7 +287,7 @@ public class DiskBasedAsyncCacheTest {
         CacheTestUtils.assertThatEntriesAreEqual(getEntry("key").get(), entry);
 
         clearEntries().get();
-        assertThat(getEntry("key").get(), is(nullValue()));
+        assertNull(getEntry("key").get());
         assertThat(listCachedFiles(), is(emptyArray()));
     }
 
@@ -356,7 +355,7 @@ public class DiskBasedAsyncCacheTest {
         Cache.Entry entry = CacheTestUtils.randomData(101);
         putEntry("key1", entry).get();
 
-        assertThat(getEntry("key1").get(), is(nullValue()));
+        assertNull(getEntry("key1").get());
 
         // confirm that we can now store entries
         putEntry("key2", entry).get();

--- a/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
@@ -1,0 +1,449 @@
+package com.android.volley.toolbox;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import androidx.annotation.Nullable;
+import com.android.volley.AsyncCache;
+import com.android.volley.Cache;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 26)
+public class DiskBasedAsyncCacheTest {
+
+    private static final int MAX_SIZE = 1024 * 1024;
+
+    private DiskBasedAsyncCache cache;
+
+    private AsyncCache.OnCompleteCallback emptyCallback;
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setup() throws IOException {
+        emptyCallback =
+                new AsyncCache.OnCompleteCallback() {
+                    @Override
+                    public void onComplete() {
+                        // do nothing
+                    }
+                };
+        // Initialize empty cache
+        cache = new DiskBasedAsyncCache(temporaryFolder.getRoot(), MAX_SIZE);
+        cache.initialize(emptyCallback);
+    }
+
+    @After
+    public void teardown() {
+        cache = null;
+    }
+
+    @Test
+    public void testEmptyInitialize() throws ExecutionException, InterruptedException {
+        assertNull(getEntry("key").get());
+    }
+
+    @Test
+    public void testPutGetZeroBytes() throws ExecutionException, InterruptedException {
+        final Cache.Entry entry = new Cache.Entry();
+
+        entry.data = new byte[0];
+        entry.serverDate = 1234567L;
+        entry.lastModified = 13572468L;
+        entry.ttl = 9876543L;
+        entry.softTtl = 8765432L;
+        entry.etag = "etag";
+        entry.responseHeaders = new HashMap<>();
+        entry.responseHeaders.put("fruit", "banana");
+        entry.responseHeaders.put("color", "yellow");
+
+        putEntry("my-magical-key", entry).get();
+
+        assertThatEntriesAreEqual(getEntry("my-magical-key").get(), entry);
+        assertThat(getEntry("unknown-key").get(), is(nullValue()));
+    }
+
+    @Test
+    public void testTooLargeEntry() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = randomData(MAX_SIZE - getEntrySizeOnDisk("oversize") + 1);
+        putEntry("oversize", entry).get();
+
+        assertThat(getEntry("oversize").get(), is(nullValue()));
+    }
+
+    @Test
+    public void testMaxSizeEntry() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = randomData(MAX_SIZE - getEntrySizeOnDisk("maxsize") - 1);
+        putEntry("maxsize", entry).get();
+
+        assertThatEntriesAreEqual(getEntry("maxsize").get(), entry);
+    }
+
+    @Test
+    public void testTrimAtThreshold() throws ExecutionException, InterruptedException {
+        // Start with the largest possible entry.
+        Cache.Entry entry = randomData(MAX_SIZE - getEntrySizeOnDisk("maxsize") - 1);
+        putEntry("maxsize", entry).get();
+
+        assertThatEntriesAreEqual(getEntry("maxsize").get(), entry);
+
+        // Now any new entry should cause the first one to be cleared.
+        entry = randomData(0);
+        putEntry("bit", entry).get();
+
+        assertThat(getEntry("goodsize").get(), is(nullValue()));
+        assertThatEntriesAreEqual(getEntry("bit").get(), entry);
+    }
+
+    @Test
+    public void testTrimWithMultipleEvictions_underHysteresisThreshold()
+            throws ExecutionException, InterruptedException {
+        final Cache.Entry entry1 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry1") - 1);
+        final Cache.Entry entry2 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry2") - 1);
+        final Cache.Entry entry3 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry3") - 1);
+
+        putEntry("entry1", entry1).get();
+        putEntry("entry2", entry2).get();
+        putEntry("entry3", entry3).get();
+
+        assertThatEntriesAreEqual(getEntry("entry1").get(), entry1);
+        assertThatEntriesAreEqual(getEntry("entry2").get(), entry2);
+        assertThatEntriesAreEqual(getEntry("entry3").get(), entry3);
+
+        final Cache.Entry entry =
+                randomData(
+                        (int) (DiskBasedCacheUtility.HYSTERESIS_FACTOR * MAX_SIZE)
+                                - getEntrySizeOnDisk("max"));
+
+        putEntry("max", entry).get();
+
+        assertThat(getEntry("entry1").get(), is(nullValue()));
+        assertThat(getEntry("entry2").get(), is(nullValue()));
+        assertThat(getEntry("entry3").get(), is(nullValue()));
+        assertThatEntriesAreEqual(getEntry("max").get(), entry);
+    }
+
+    @Test
+    public void testTrimWithMultipleEvictions_atHysteresisThreshold()
+            throws ExecutionException, InterruptedException {
+        final Cache.Entry entry1 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry1") - 1);
+        final Cache.Entry entry2 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry2") - 1);
+        final Cache.Entry entry3 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry3") - 1);
+
+        putEntry("entry1", entry1).get();
+        putEntry("entry2", entry2).get();
+        putEntry("entry3", entry3).get();
+
+        assertThatEntriesAreEqual(getEntry("entry1").get(), entry1);
+        assertThatEntriesAreEqual(getEntry("entry2").get(), entry2);
+        assertThatEntriesAreEqual(getEntry("entry3").get(), entry3);
+
+        final Cache.Entry entry =
+                randomData(
+                        (int) (DiskBasedCacheUtility.HYSTERESIS_FACTOR * MAX_SIZE)
+                                - getEntrySizeOnDisk("max")
+                                + 1);
+
+        putEntry("max", entry).get();
+
+        assertThat(getEntry("entry1").get(), is(nullValue()));
+        assertThat(getEntry("entry2").get(), is(nullValue()));
+        assertThat(getEntry("entry3").get(), is(nullValue()));
+        assertThat(getEntry("max").get(), is(nullValue()));
+    }
+
+    @Test
+    public void testTrimWithPartialEvictions() throws ExecutionException, InterruptedException {
+        final Cache.Entry entry1 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry1") - 1);
+        final Cache.Entry entry2 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry2") - 1);
+        final Cache.Entry entry3 = randomData(MAX_SIZE / 3 - getEntrySizeOnDisk("entry3") - 1);
+        final Cache.Entry entry4 = randomData((MAX_SIZE - getEntrySizeOnDisk("entry4") - 1) / 2);
+
+        putEntry("entry1", entry1).get();
+        putEntry("entry2", entry2).get();
+        putEntry("entry3", entry3).get();
+
+        assertThatEntriesAreEqual(getEntry("entry1").get(), entry1);
+        assertThatEntriesAreEqual(getEntry("entry2").get(), entry2);
+        assertThatEntriesAreEqual(getEntry("entry3").get(), entry3);
+
+        putEntry("entry4", entry4).get();
+
+        assertThat(getEntry("entry1").get(), is(nullValue()));
+        assertThat(getEntry("entry2").get(), is(nullValue()));
+        assertThatEntriesAreEqual(getEntry("entry3").get(), entry3);
+        assertThatEntriesAreEqual(getEntry("entry4").get(), entry4);
+    }
+
+    @Test
+    public void testGetBadMagic() throws IOException, ExecutionException, InterruptedException {
+        // Cache something
+        Cache.Entry entry = randomData(1023);
+        putEntry("key", entry).get();
+        assertThatEntriesAreEqual(getEntry("key").get(), entry);
+
+        // Overwrite the magic header
+        File cacheFolder = temporaryFolder.getRoot();
+        File file = cacheFolder.listFiles()[0];
+        FileOutputStream fos = new FileOutputStream(file);
+        DiskBasedCacheUtility.writeInt(fos, 0);
+        fos.close();
+        assertThat(getEntry("key").get(), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray())); // should this be??
+    }
+
+    @Test
+    public void testGetWrongKey() throws IOException, ExecutionException, InterruptedException {
+        // Cache something
+        Cache.Entry entry = randomData(1023);
+        putEntry("key", entry).get();
+        assertThatEntriesAreEqual(getEntry("key").get(), entry);
+
+        // Access the cached file
+        File cacheFolder = temporaryFolder.getRoot();
+        File file = cacheFolder.listFiles()[0];
+
+        // Write a new header to file associated with key
+        AsynchronousFileChannel afc =
+                AsynchronousFileChannel.open(file.toPath(), StandardOpenOption.WRITE);
+        CacheHeader wrongHeader = new CacheHeader("bad", entry);
+        ByteBuffer buffer = ByteBuffer.allocate(59);
+        wrongHeader.writeHeader(buffer);
+        buffer.flip();
+        Future<Integer> operation = afc.write(buffer, 0);
+        operation.get();
+        afc.close();
+
+        // key is gone, but file is still there
+        assertThat(getEntry("key").get(), is(nullValue()));
+        assertThat(listCachedFiles(), is(arrayWithSize(1)));
+
+        // Note: file is now a zombie because its key does not map to its name
+    }
+
+    @Test
+    public void testPutRemoveGet() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = randomData(511);
+        putEntry("key", entry).get();
+
+        assertThatEntriesAreEqual(getEntry("key").get(), entry);
+
+        removeEntry("key").get();
+        assertThat(getEntry("key").get(), is(nullValue()));
+        assertThat(listCachedFiles(), is(emptyArray()));
+    }
+
+    @Test
+    public void testPutClearGet() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = randomData(511);
+        putEntry("key", entry).get();
+
+        assertThatEntriesAreEqual(getEntry("key").get(), entry);
+
+        cache.clear(
+                new AsyncCache.OnCompleteCallback() {
+                    @Override
+                    public void onComplete() {
+                        try {
+                            assertThat(getEntry("key").get(), is(nullValue()));
+                        } catch (ExecutionException e) {
+                            // do nothing
+                        } catch (InterruptedException e) {
+                            // do nothing
+                        }
+                        assertThat(listCachedFiles(), is(emptyArray()));
+                    }
+                });
+    }
+
+    @Test
+    public void testReinitialize() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = randomData(1023);
+        putEntry("key", entry).get();
+
+        AsyncCache copy = new DiskBasedAsyncCache(temporaryFolder.getRoot(), MAX_SIZE);
+        copy.initialize(emptyCallback);
+
+        final CompletableFuture<Cache.Entry> getEntry = new CompletableFuture<>();
+        copy.get(
+                "key",
+                new AsyncCache.OnGetCompleteCallback() {
+                    @Override
+                    public void onGetComplete(@Nullable Cache.Entry entry) {
+                        getEntry.complete(entry);
+                    }
+                });
+
+        assertThatEntriesAreEqual(getEntry.get(), entry);
+    }
+
+    @Test
+    public void testInvalidate() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = randomData(32);
+        entry.softTtl = 8765432L;
+        entry.ttl = 9876543L;
+        putEntry("key", entry).get();
+
+        invalidateEntry("key", false).get();
+        entry.softTtl = 0; // expired
+        assertThatEntriesAreEqual(getEntry("key").get(), entry);
+    }
+
+    @Test
+    public void testInvalidateFullExpire() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = randomData(32);
+        entry.softTtl = 8765432L;
+        entry.ttl = 9876543L;
+        putEntry("key", entry).get();
+
+        invalidateEntry("key", true).get();
+        entry.softTtl = 0; // expired
+        entry.ttl = 0; // expired
+        assertThatEntriesAreEqual(getEntry("key").get(), entry);
+    }
+
+    @Test
+    public void testManyResponseHeaders() throws ExecutionException, InterruptedException {
+        Cache.Entry entry = new Cache.Entry();
+        entry.data = new byte[0];
+        entry.responseHeaders = new HashMap<>();
+        for (int i = 0; i < 0xFFFF; i++) {
+            entry.responseHeaders.put(Integer.toString(i), "");
+        }
+        putEntry("key", entry).get();
+    }
+
+    @Test
+    public void initializeIfRootDirectoryDeleted() throws ExecutionException, InterruptedException {
+        temporaryFolder.delete();
+
+        Cache.Entry entry = randomData(101);
+        putEntry("key1", entry).get();
+
+        assertThat(getEntry("key1").get(), is(nullValue()));
+
+        // confirm that we can now store entries
+        putEntry("key2", entry).get();
+        assertThatEntriesAreEqual(getEntry("key2").get(), entry);
+    }
+
+    /* Test helpers */
+
+    /** Puts entry into the cache, and returns a CompletableFuture, to let us know when it's done */
+    private CompletableFuture<Void> putEntry(final String key, Cache.Entry entry) {
+        final CompletableFuture<Void> put = new CompletableFuture<>();
+        cache.put(
+                key,
+                entry,
+                new AsyncCache.OnCompleteCallback() {
+                    @Override
+                    public void onComplete() {
+                        put.complete(null);
+                    }
+                });
+        return put;
+    }
+
+    /** Gets an entry from the cache, and returns a CompletableFuture containing the entry */
+    private CompletableFuture<Cache.Entry> getEntry(final String key) {
+        final CompletableFuture<Cache.Entry> get = new CompletableFuture<>();
+        cache.get(
+                key,
+                new AsyncCache.OnGetCompleteCallback() {
+                    @Override
+                    public void onGetComplete(@Nullable Cache.Entry entry) {
+                        get.complete(entry);
+                    }
+                });
+        return get;
+    }
+
+    private CompletableFuture<Void> removeEntry(final String key) {
+        final CompletableFuture<Void> remove = new CompletableFuture<>();
+        cache.remove(
+                key,
+                new AsyncCache.OnCompleteCallback() {
+                    @Override
+                    public void onComplete() {
+                        remove.complete(null);
+                    }
+                });
+        return remove;
+    }
+
+    private CompletableFuture<Void> invalidateEntry(final String key, final boolean fullExpire) {
+        final CompletableFuture<Void> remove = new CompletableFuture<>();
+        cache.invalidate(
+                key,
+                fullExpire,
+                new AsyncCache.OnCompleteCallback() {
+                    @Override
+                    public void onComplete() {
+                        remove.complete(null);
+                    }
+                });
+        return remove;
+    }
+
+    private void assertThatEntriesAreEqual(Cache.Entry actual, Cache.Entry expected) {
+        assertNotNull(actual);
+        assertThat(actual.data, is(equalTo(expected.data)));
+        assertThat(actual.etag, is(equalTo(expected.etag)));
+        assertThat(actual.lastModified, is(equalTo(expected.lastModified)));
+        assertThat(actual.responseHeaders, is(equalTo(expected.responseHeaders)));
+        assertThat(actual.serverDate, is(equalTo(expected.serverDate)));
+        assertThat(actual.softTtl, is(equalTo(expected.softTtl)));
+        assertThat(actual.ttl, is(equalTo(expected.ttl)));
+    }
+
+    private Cache.Entry randomData(int length) {
+        Cache.Entry entry = new Cache.Entry();
+        byte[] data = new byte[length];
+        new Random(42).nextBytes(data); // explicit seed for reproducible results
+        entry.data = data;
+        return entry;
+    }
+
+    private File[] listCachedFiles() {
+        return temporaryFolder.getRoot().listFiles();
+    }
+
+    private int getEntrySizeOnDisk(String key) {
+        // Header size is:
+        // 4 bytes for magic int
+        // 8 + len(key) bytes for key (long length)
+        // 8 bytes for etag (long length + 0 characters)
+        // 32 bytes for serverDate, lastModified, ttl, and softTtl longs
+        // 4 bytes for length of header list int
+        // == 56 + len(key) bytes total.
+        return 56 + key.length();
+    }
+}

--- a/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
@@ -37,7 +37,7 @@ public class DiskBasedAsyncCacheTest {
 
     private DiskBasedAsyncCache cache;
 
-    private AsyncCache.OnCompleteCallback emptyCallback;
+    private AsyncCache.OnWriteCompleteCallback emptyCallback;
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -47,9 +47,9 @@ public class DiskBasedAsyncCacheTest {
     public void setup() throws IOException, ExecutionException, InterruptedException {
         final CompletableFuture<Void> future = new CompletableFuture<>();
         emptyCallback =
-                new AsyncCache.OnCompleteCallback() {
+                new AsyncCache.OnWriteCompleteCallback() {
                     @Override
-                    public void onComplete() {
+                    public void onWriteComplete() {
                         future.complete(null);
                     }
                 };
@@ -370,9 +370,9 @@ public class DiskBasedAsyncCacheTest {
         cache.put(
                 key,
                 entry,
-                new AsyncCache.OnCompleteCallback() {
+                new AsyncCache.OnWriteCompleteCallback() {
                     @Override
-                    public void onComplete() {
+                    public void onWriteComplete() {
                         put.complete(null);
                     }
                 });
@@ -397,9 +397,9 @@ public class DiskBasedAsyncCacheTest {
         final CompletableFuture<Void> remove = new CompletableFuture<>();
         cache.remove(
                 key,
-                new AsyncCache.OnCompleteCallback() {
+                new AsyncCache.OnWriteCompleteCallback() {
                     @Override
-                    public void onComplete() {
+                    public void onWriteComplete() {
                         remove.complete(null);
                     }
                 });
@@ -411,9 +411,9 @@ public class DiskBasedAsyncCacheTest {
         cache.invalidate(
                 key,
                 fullExpire,
-                new AsyncCache.OnCompleteCallback() {
+                new AsyncCache.OnWriteCompleteCallback() {
                     @Override
-                    public void onComplete() {
+                    public void onWriteComplete() {
                         remove.complete(null);
                     }
                 });
@@ -423,9 +423,9 @@ public class DiskBasedAsyncCacheTest {
     private CompletableFuture<Void> clearEntries() {
         final CompletableFuture<Void> clear = new CompletableFuture<>();
         cache.clear(
-                new AsyncCache.OnCompleteCallback() {
+                new AsyncCache.OnWriteCompleteCallback() {
                     @Override
-                    public void onComplete() {
+                    public void onWriteComplete() {
                         clear.complete(null);
                     }
                 });

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -178,7 +178,7 @@ public class DiskBasedCacheTest {
     @Test
     public void testTrimAtThreshold() {
         // Start with the largest possible entry.
-        Cache.Entry entry = randomData(MAX_SIZE - getEntrySizeOnDisk("maxsize") - 1);
+        Cache.Entry entry = randomData(MAX_SIZE - getEntrySizeOnDisk("maxsize"));
         cache.put("maxsize", entry);
 
         assertThatEntriesAreEqual(cache.get("maxsize"), entry);
@@ -187,7 +187,7 @@ public class DiskBasedCacheTest {
         entry = randomData(0);
         cache.put("bit", entry);
 
-        assertThat(cache.get("goodsize"), is(nullValue()));
+        assertThat(cache.get("maxsize"), is(nullValue()));
         assertThatEntriesAreEqual(cache.get("bit"), entry);
     }
 

--- a/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedCacheTest.java
@@ -19,8 +19,8 @@ package com.android.volley.toolbox;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -77,7 +77,7 @@ public class DiskBasedCacheTest {
 
     @Test
     public void testEmptyInitialize() {
-        assertThat(cache.get("key"), is(nullValue()));
+        assertNull(cache.get("key"));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class DiskBasedCacheTest {
         cache.put("my-magical-key", entry);
 
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("my-magical-key"), entry);
-        assertThat(cache.get("unknown-key"), is(nullValue()));
+        assertNull(cache.get("unknown-key"));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class DiskBasedCacheTest {
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("key"), entry);
 
         cache.remove("key");
-        assertThat(cache.get("key"), is(nullValue()));
+        assertNull(cache.get("key"));
         assertThat(listCachedFiles(), is(emptyArray()));
     }
 
@@ -118,7 +118,7 @@ public class DiskBasedCacheTest {
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("key"), entry);
 
         cache.clear();
-        assertThat(cache.get("key"), is(nullValue()));
+        assertNull(cache.get("key"));
         assertThat(listCachedFiles(), is(emptyArray()));
     }
 
@@ -165,7 +165,7 @@ public class DiskBasedCacheTest {
                         MAX_SIZE - CacheTestUtils.getEntrySizeOnDisk("oversize") + 1);
         cache.put("oversize", entry);
 
-        assertThat(cache.get("oversize"), is(nullValue()));
+        assertNull(cache.get("oversize"));
     }
 
     @Test
@@ -191,7 +191,7 @@ public class DiskBasedCacheTest {
         entry = CacheTestUtils.randomData(0);
         cache.put("bit", entry);
 
-        assertThat(cache.get("maxsize"), is(nullValue()));
+        assertNull(cache.get("maxsize"));
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("bit"), entry);
     }
 
@@ -220,9 +220,9 @@ public class DiskBasedCacheTest {
                                 - CacheTestUtils.getEntrySizeOnDisk("max"));
         cache.put("max", entry);
 
-        assertThat(cache.get("entry1"), is(nullValue()));
-        assertThat(cache.get("entry2"), is(nullValue()));
-        assertThat(cache.get("entry3"), is(nullValue()));
+        assertNull(cache.get("entry1"));
+        assertNull(cache.get("entry2"));
+        assertNull(cache.get("entry3"));
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("max"), entry);
     }
 
@@ -252,10 +252,10 @@ public class DiskBasedCacheTest {
                                 + 1);
         cache.put("max", entry);
 
-        assertThat(cache.get("entry1"), is(nullValue()));
-        assertThat(cache.get("entry2"), is(nullValue()));
-        assertThat(cache.get("entry3"), is(nullValue()));
-        assertThat(cache.get("max"), is(nullValue()));
+        assertNull(cache.get("entry1"));
+        assertNull(cache.get("entry2"));
+        assertNull(cache.get("entry3"));
+        assertNull(cache.get("max"));
     }
 
     @Test
@@ -282,8 +282,8 @@ public class DiskBasedCacheTest {
                         (MAX_SIZE - CacheTestUtils.getEntrySizeOnDisk("entry4") - 1) / 2);
         cache.put("entry4", entry4);
 
-        assertThat(cache.get("entry1"), is(nullValue()));
-        assertThat(cache.get("entry2"), is(nullValue()));
+        assertNull(cache.get("entry1"));
+        assertNull(cache.get("entry2"));
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("entry3"), entry3);
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("entry4"), entry4);
     }
@@ -311,7 +311,7 @@ public class DiskBasedCacheTest {
         // the whole cache, since the large entry is above the hysteresis threshold.
         cache.put("largeEntry", largeEntry);
 
-        assertThat(cache.get("largeEntry"), is(nullValue()));
+        assertNull(cache.get("largeEntry"));
         CacheTestUtils.assertThatEntriesAreEqual(cache.get("entry"), entry);
     }
 
@@ -334,7 +334,7 @@ public class DiskBasedCacheTest {
             fos.close();
         }
 
-        assertThat(cache.get("key"), is(nullValue()));
+        assertNull(cache.get("key"));
         assertThat(listCachedFiles(), is(emptyArray()));
     }
 
@@ -360,7 +360,7 @@ public class DiskBasedCacheTest {
         }
 
         // key is gone, but file is still there
-        assertThat(cache.get("key"), is(nullValue()));
+        assertNull(cache.get("key"));
         assertThat(listCachedFiles(), is(arrayWithSize(1)));
 
         // Note: file is now a zombie because its key does not map to its name
@@ -409,11 +409,11 @@ public class DiskBasedCacheTest {
 
         // write is called at least once because each linked stream flushes when closed
         verify(mockedOutputStream, atLeastOnce()).write(anyInt());
-        assertThat(readonly.get("key"), is(nullValue()));
+        assertNull(cache.get("key"));
         assertThat(listCachedFiles(), is(emptyArray()));
 
         // Note: original cache will try (without success) to read from file
-        assertThat(cache.get("key"), is(nullValue()));
+        assertNull(cache.get("key"));
     }
 
     @Test
@@ -436,15 +436,15 @@ public class DiskBasedCacheTest {
         broken.initialize();
 
         // Everything is gone
-        assertThat(broken.get("kilobyte"), is(nullValue()));
-        assertThat(broken.get("kilobyte2"), is(nullValue()));
-        assertThat(broken.get("kilobyte3"), is(nullValue()));
+        assertNull(broken.get("kilobyte"));
+        assertNull(broken.get("kilobyte2"));
+        assertNull(broken.get("kilobyte3"));
         assertThat(listCachedFiles(), is(emptyArray()));
 
         // Verify that original cache can cope with missing files
-        assertThat(cache.get("kilobyte"), is(nullValue()));
-        assertThat(cache.get("kilobyte2"), is(nullValue()));
-        assertThat(cache.get("kilobyte3"), is(nullValue()));
+        assertNull(cache.get("kilobyte"));
+        assertNull(cache.get("kilobyte2"));
+        assertNull(cache.get("kilobyte3"));
     }
 
     @Test
@@ -519,7 +519,7 @@ public class DiskBasedCacheTest {
         Cache.Entry entry = CacheTestUtils.randomData(101);
         cache.put("key1", entry);
 
-        assertThat(cache.get("key1"), is(nullValue()));
+        assertNull(cache.get("key1"));
 
         // confirm that we can now store entries
         cache.put("key2", entry);

--- a/src/test/java/com/android/volley/utils/CacheTestUtils.java
+++ b/src/test/java/com/android/volley/utils/CacheTestUtils.java
@@ -16,6 +16,11 @@
 
 package com.android.volley.utils;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
 import com.android.volley.Cache;
 import java.util.Random;
 
@@ -50,5 +55,35 @@ public class CacheTestUtils {
      */
     public static Cache.Entry makeRandomCacheEntry(byte[] data) {
         return makeRandomCacheEntry(data, false, false);
+    }
+
+    public static void assertThatEntriesAreEqual(Cache.Entry actual, Cache.Entry expected) {
+        assertNotNull(actual);
+        assertThat(actual.data, is(equalTo(expected.data)));
+        assertThat(actual.etag, is(equalTo(expected.etag)));
+        assertThat(actual.lastModified, is(equalTo(expected.lastModified)));
+        assertThat(actual.responseHeaders, is(equalTo(expected.responseHeaders)));
+        assertThat(actual.serverDate, is(equalTo(expected.serverDate)));
+        assertThat(actual.softTtl, is(equalTo(expected.softTtl)));
+        assertThat(actual.ttl, is(equalTo(expected.ttl)));
+    }
+
+    public static Cache.Entry randomData(int length) {
+        Cache.Entry entry = new Cache.Entry();
+        byte[] data = new byte[length];
+        new Random(42).nextBytes(data); // explicit seed for reproducible results
+        entry.data = data;
+        return entry;
+    }
+
+    public static int getEntrySizeOnDisk(String key) {
+        // Header size is:
+        // 4 bytes for magic int
+        // 8 + len(key) bytes for key (long length)
+        // 8 bytes for etag (long length + 0 characters)
+        // 32 bytes for serverDate, lastModified, ttl, and softTtl longs
+        // 4 bytes for length of header list int
+        // == 56 + len(key) bytes total.
+        return 56 + key.length();
     }
 }


### PR DESCRIPTION
I've implemented the remaining methods in AsyncCache (clear, initialize, remove, invalidate), added a readHeader method to CacheHeader (for validity check in get, and use in initialize), and added tests that test same things as in DiskBasedCacheTest.

Few things to point out about this PR:
- I made a generalized callback interface, since it was the exact same for put, clear, initialize, remove and invalidate. At this point, I didn't see a need for each one to have their own interface.
- Invalidate throws ExecutionException & InterruptedException, since I use completable futures there. Currently I just log the error, but wasn't sure if something more needed to be done in that instance. Also could not use futures, and put code in callbacks, but that seemed a lot less readable.
- I changed helper method closeChannel to return true in the case the channel was null, since no error was thrown.
- I did not include thread safety fixes on this PR. I am still working on finishing up that code, and was going to submit them in a separate PR.