### PR TITLE
AsyncNetwork implementation as well as unit testing

### DIFF
--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -32,7 +32,7 @@ public abstract class AsyncNetwork implements Network {
         mAsyncStack = stack;
     }
 
-    /** Inteface for callback to be called after request is processed */
+    /** Inteface for callback to be called after request is processed. */
     public interface OnRequestComplete {
         /** Method to be called after successful network request. */
         void onSuccess(NetworkResponse networkResponse);

--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -25,8 +25,8 @@ import java.util.concurrent.atomic.AtomicReference;
 /** An asynchronous implementation of {@link Network} to perform requests. */
 public abstract class AsyncNetwork implements Network {
     protected AsyncHttpStack mAsyncStack;
-    protected ExecutorService mBlockingExecutor;
-    protected ExecutorService mNonBlockingExecutor;
+    private ExecutorService mBlockingExecutor;
+    private ExecutorService mNonBlockingExecutor;
 
     protected AsyncNetwork(AsyncHttpStack stack) {
         mAsyncStack = stack;
@@ -113,5 +113,13 @@ public abstract class AsyncNetwork implements Network {
     public void setBlockingExecutor(ExecutorService executor) {
         mBlockingExecutor = executor;
         mAsyncStack.setBlockingExecutor(executor);
+    }
+
+    protected ExecutorService getBlockingExecutor() {
+        return mBlockingExecutor;
+    }
+
+    protected ExecutorService getNonBlockingExecutor() {
+        return mNonBlockingExecutor;
     }
 }

--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -32,9 +32,12 @@ public abstract class AsyncNetwork implements Network {
         mAsyncStack = stack;
     }
 
+    /** Inteface for callback to be called after request is processed */
     public interface OnRequestComplete {
+        /** Method to be called after successful network request. */
         void onSuccess(NetworkResponse networkResponse);
 
+        /** Method to be called after unsuccessful network request. */
         void onError(VolleyError volleyError);
     }
 
@@ -91,11 +94,11 @@ public abstract class AsyncNetwork implements Network {
     }
 
     /**
-     * This method sets the non blocking executor to be used by the stack for non-blocking tasks.
-     * This method must be called before performing any requests.
+     * This method sets the non blocking executor to be used by the network and stack for
+     * non-blocking tasks. This method must be called before performing any requests.
      */
     @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
-    public void setNonBlockingExecutorForStack(ExecutorService executor) {
+    public void setNonBlockingExecutor(ExecutorService executor) {
         mNonBlockingExecutor = executor;
         mAsyncStack.setNonBlockingExecutor(executor);
     }
@@ -110,14 +113,17 @@ public abstract class AsyncNetwork implements Network {
         mAsyncStack.setBlockingExecutor(executor);
     }
 
+    /** Gets blocking executor to perform any potentially blocking tasks. */
     protected ExecutorService getBlockingExecutor() {
         return mBlockingExecutor;
     }
 
+    /** Gets non-blocking executor to perform any non-blocking tasks. */
     protected ExecutorService getNonBlockingExecutor() {
         return mNonBlockingExecutor;
     }
 
+    /** Gets the {@link AsyncHttpStack} to be used by the network. */
     protected AsyncHttpStack getHttpStack() {
         return mAsyncStack;
     }

--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -63,8 +63,10 @@ public abstract class AsyncNetwork implements Network {
         Response response = entry.get();
         if (response.networkResponse != null) {
             return response.networkResponse;
-        } else {
+        } else if (response.volleyError != null) {
             throw response.volleyError;
+        } else {
+            throw new VolleyError("Neither response entry was set");
         }
     }
 
@@ -74,7 +76,7 @@ public abstract class AsyncNetwork implements Network {
      * nothing. This method must be called before performing any requests if you are using an
      * AsyncHttpStack.
      */
-    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
+    @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
     public abstract void setNonBlockingExecutorForStack(ExecutorService executor);
 
     /**
@@ -83,12 +85,12 @@ public abstract class AsyncNetwork implements Network {
      * executor for the stack if it is an instance of {@link
      * com.android.volley.toolbox.AsyncHttpStack}
      */
-    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
+    @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
     public abstract void setBlockingExecutor(ExecutorService executor);
 
     static class Response {
-        NetworkResponse networkResponse;
-        VolleyError volleyError;
+        @Nullable NetworkResponse networkResponse;
+        @Nullable VolleyError volleyError;
 
         private Response(@Nullable NetworkResponse networkResponse, @Nullable VolleyError error) {
             this.networkResponse = networkResponse;

--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /** An asynchronous implementation of {@link Network} to perform requests. */
 public abstract class AsyncNetwork implements Network {
-    protected AsyncHttpStack mAsyncStack;
+    private final AsyncHttpStack mAsyncStack;
     private ExecutorService mBlockingExecutor;
     private ExecutorService mNonBlockingExecutor;
 
@@ -55,7 +55,6 @@ public abstract class AsyncNetwork implements Network {
      */
     @Override
     public NetworkResponse performRequest(Request<?> request) throws VolleyError {
-        // Is there a better way to go about this?
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<NetworkResponse> response = new AtomicReference<>();
         final AtomicReference<VolleyError> error = new AtomicReference<>();
@@ -92,10 +91,8 @@ public abstract class AsyncNetwork implements Network {
     }
 
     /**
-     * This method sets the non blocking executor to be used by the stack for non-blocking tasks. If
-     * you are not using an {@link com.android.volley.toolbox.AsyncHttpStack}, this should do
-     * nothing. This method must be called before performing any requests if you are using an
-     * AsyncHttpStack.
+     * This method sets the non blocking executor to be used by the stack for non-blocking tasks.
+     * This method must be called before performing any requests if you are using an AsyncHttpStack.
      */
     @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
     public void setNonBlockingExecutorForStack(ExecutorService executor) {
@@ -105,9 +102,7 @@ public abstract class AsyncNetwork implements Network {
 
     /**
      * This method sets the blocking executor to be used by the network and stack for potentially
-     * blocking tasks. This method must be called before performing any requests. Only set the
-     * executor for the stack if it is an instance of {@link
-     * com.android.volley.toolbox.AsyncHttpStack}
+     * blocking tasks. This method must be called before performing any requests.
      */
     @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
     public void setBlockingExecutor(ExecutorService executor) {
@@ -121,5 +116,9 @@ public abstract class AsyncNetwork implements Network {
 
     protected ExecutorService getNonBlockingExecutor() {
         return mNonBlockingExecutor;
+    }
+
+    protected AsyncHttpStack getHttpStack() {
+        return mAsyncStack;
     }
 }

--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+public abstract class AsyncNetwork implements Network {
+
+    public interface OnRequestComplete {
+        void onSuccess(NetworkResponse networkResponse);
+
+        void onError(VolleyError volleyError);
+    }
+
+    public abstract void performRequest(Request<?> request, OnRequestComplete callback);
+
+    @Override
+    public NetworkResponse performRequest(Request<?> request) throws VolleyError {
+        // Is there a better way to go about this?
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Response> entry = new AtomicReference<>();
+        performRequest(
+                request,
+                new OnRequestComplete() {
+                    @Override
+                    public void onSuccess(NetworkResponse networkResponse) {
+                        entry.set(new Response(networkResponse, /* error= */ null));
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onError(VolleyError volleyError) {
+                        entry.set(new Response(/* networkResponse= */ null, volleyError));
+                        latch.countDown();
+                    }
+                });
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            VolleyLog.e(e, "while waiting for CountDownLatch");
+            Thread.currentThread().interrupt();
+            throw new VolleyError(e);
+        }
+
+        Response response = entry.get();
+        if (response.networkResponse != null) {
+            return response.networkResponse;
+        } else {
+            throw response.volleyError;
+        }
+    }
+
+    /**
+     * This method sets the non blocking executor to be used by the stack for non-blocking tasks. If
+     * you are not using an {@link com.android.volley.toolbox.AsyncHttpStack}, this should do
+     * nothing. This method must be called before performing any requests if you are using an
+     * AsyncHttpStack.
+     */
+    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
+    public abstract void setNonBlockingExecutorForStack(ExecutorService executor);
+
+    /**
+     * This method sets the blocking executor to be used by the network and stack for potentially
+     * blocking tasks. This method must be called before performing any requests. Only set the
+     * executor for the stack if it is an instance of {@link
+     * com.android.volley.toolbox.AsyncHttpStack}
+     */
+    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
+    public abstract void setBlockingExecutor(ExecutorService executor);
+
+    static class Response {
+        NetworkResponse networkResponse;
+        VolleyError volleyError;
+
+        private Response(@Nullable NetworkResponse networkResponse, @Nullable VolleyError error) {
+            this.networkResponse = networkResponse;
+            volleyError = error;
+        }
+    }
+}

--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -32,7 +32,7 @@ public abstract class AsyncNetwork implements Network {
         mAsyncStack = stack;
     }
 
-    /** Inteface for callback to be called after request is processed. */
+    /** Interface for callback to be called after request is processed. */
     public interface OnRequestComplete {
         /** Method to be called after successful network request. */
         void onSuccess(NetworkResponse networkResponse);

--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -92,7 +92,7 @@ public abstract class AsyncNetwork implements Network {
 
     /**
      * This method sets the non blocking executor to be used by the stack for non-blocking tasks.
-     * This method must be called before performing any requests if you are using an AsyncHttpStack.
+     * This method must be called before performing any requests.
      */
     @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
     public void setNonBlockingExecutorForStack(ExecutorService executor) {

--- a/src/main/java/com/android/volley/cronet/CronetHttpStack.java
+++ b/src/main/java/com/android/volley/cronet/CronetHttpStack.java
@@ -65,7 +65,7 @@ public class CronetHttpStack extends AsyncHttpStack {
             final Map<String, String> additionalHeaders,
             final OnRequestComplete callback) {
         if (getBlockingExecutor() == null || getNonBlockingExecutor() == null) {
-            throw new IllegalStateException("Must set blocking / non-blocking executors");
+            throw new IllegalStateException("Must set blocking and non-blocking executors");
         }
         final Callback urlCallback =
                 new Callback() {

--- a/src/main/java/com/android/volley/cronet/CronetHttpStack.java
+++ b/src/main/java/com/android/volley/cronet/CronetHttpStack.java
@@ -17,8 +17,9 @@
 package com.android.volley.cronet;
 
 import android.content.Context;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.android.volley.AuthFailureError;
 import com.android.volley.Header;
@@ -36,7 +37,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 import org.chromium.net.CronetEngine;
 import org.chromium.net.CronetException;
 import org.chromium.net.UploadDataProvider;
@@ -51,16 +51,12 @@ import org.chromium.net.UrlResponseInfo;
 public class CronetHttpStack extends AsyncHttpStack {
 
     private final CronetEngine mCronetEngine;
-    private ExecutorService mCallbackExecutor;
-    private ExecutorService mBlockingExecutor;
     private final ByteArrayPool mPool;
     private final UrlRewriter mUrlRewriter;
 
     private CronetHttpStack(
             CronetEngine cronetEngine, ByteArrayPool pool, UrlRewriter urlRewriter) {
         mCronetEngine = cronetEngine;
-        mCallbackExecutor = null;
-        mBlockingExecutor = null;
         mPool = pool;
         mUrlRewriter = urlRewriter;
     }
@@ -70,7 +66,7 @@ public class CronetHttpStack extends AsyncHttpStack {
             final Request<?> request,
             final Map<String, String> additionalHeaders,
             final OnRequestComplete callback) {
-        if (mBlockingExecutor == null || mCallbackExecutor == null) {
+        if (getBlockingExecutor() == null || getNonBlockingExecutor() == null) {
             throw new IllegalStateException("Must set blocking / non-blocking executors");
         }
         final Callback urlCallback =
@@ -145,51 +141,26 @@ public class CronetHttpStack extends AsyncHttpStack {
         // the callbacks are non-blocking.
         final UrlRequest.Builder builder =
                 mCronetEngine
-                        .newUrlRequestBuilder(url, urlCallback, mCallbackExecutor)
+                        .newUrlRequestBuilder(url, urlCallback, getNonBlockingExecutor())
                         .allowDirectExecutor()
                         .disableCache()
                         .setPriority(getPriority(request));
         // request.getHeaders() may be blocking, so submit it to the blocking executor.
-        mBlockingExecutor.execute(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            setHttpMethod(request, builder);
-                            setRequestHeaders(request, additionalHeaders, builder);
-                            UrlRequest urlRequest = builder.build();
-                            urlRequest.start();
-                        } catch (AuthFailureError authFailureError) {
-                            callback.onAuthError(authFailureError);
-                        }
-                    }
-                });
-    }
-
-    /**
-     * This method sets the non blocking executor to be used by the stack for non-blocking tasks.
-     * This method must be called before executing any requests.
-     */
-    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
-    @Override
-    public void setNonBlockingExecutor(ExecutorService executor) {
-        if (executor == null) {
-            throw new IllegalArgumentException("Cannot set executor to be null");
-        }
-        mCallbackExecutor = executor;
-    }
-
-    /**
-     * This method sets the blocking executor to be used by the stack for potentially blocking
-     * tasks. This method must be called before executing any requests.
-     */
-    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
-    @Override
-    public void setBlockingExecutor(ExecutorService executor) {
-        if (executor == null) {
-            throw new IllegalArgumentException("Cannot set executor to be null");
-        }
-        mBlockingExecutor = executor;
+        getBlockingExecutor()
+                .execute(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                try {
+                                    setHttpMethod(request, builder);
+                                    setRequestHeaders(request, additionalHeaders, builder);
+                                    UrlRequest urlRequest = builder.build();
+                                    urlRequest.start();
+                                } catch (AuthFailureError authFailureError) {
+                                    callback.onAuthError(authFailureError);
+                                }
+                            }
+                        });
     }
 
     @VisibleForTesting
@@ -275,7 +246,7 @@ public class CronetHttpStack extends AsyncHttpStack {
     private void addBodyIfExists(@Nullable byte[] body, UrlRequest.Builder builder) {
         if (body != null) {
             UploadDataProvider dataProvider = UploadDataProviders.create(body);
-            builder.setUploadDataProvider(dataProvider, mCallbackExecutor);
+            builder.setUploadDataProvider(dataProvider, getNonBlockingExecutor());
         }
     }
 
@@ -314,6 +285,7 @@ public class CronetHttpStack extends AsyncHttpStack {
         private UrlRewriter mUrlRewriter;
 
         public Builder(Context context) {
+            this.context = context;
             mCronetEngine = null;
             mPool = null;
             mUrlRewriter = null;

--- a/src/main/java/com/android/volley/cronet/CronetHttpStack.java
+++ b/src/main/java/com/android/volley/cronet/CronetHttpStack.java
@@ -17,8 +17,6 @@
 package com.android.volley.cronet;
 
 import android.content.Context;
-
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.android.volley.AuthFailureError;
@@ -280,7 +278,7 @@ public class CronetHttpStack extends AsyncHttpStack {
     public static class Builder {
         private static final int DEFAULT_POOL_SIZE = 4096;
         private CronetEngine mCronetEngine;
-        private Context context;
+        private final Context context;
         private ByteArrayPool mPool;
         private UrlRewriter mUrlRewriter;
 

--- a/src/main/java/com/android/volley/toolbox/AsyncHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/AsyncHttpStack.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /** Asynchronous extension of the {@link BaseHttpStack} class. */
 public abstract class AsyncHttpStack extends BaseHttpStack {
+    private ExecutorService mBlockingExecutor;
+    private ExecutorService mNonBlockingExecutor;
 
     public interface OnRequestComplete {
         /** Invoked when the stack successfully completes a request. */
@@ -58,14 +60,26 @@ public abstract class AsyncHttpStack extends BaseHttpStack {
      * This method must be called before executing any requests.
      */
     @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
-    public abstract void setNonBlockingExecutor(ExecutorService executor);
+    public void setNonBlockingExecutor(ExecutorService executor) {
+        mNonBlockingExecutor = executor;
+    }
 
     /**
      * This method sets the blocking executor to be used by the stack for potentially blocking
      * tasks. This method must be called before executing any requests.
      */
     @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
-    public abstract void setBlockingExecutor(ExecutorService executor);
+    public void setBlockingExecutor(ExecutorService executor) {
+        mBlockingExecutor = executor;
+    }
+
+    protected ExecutorService getBlockingExecutor() {
+        return mBlockingExecutor;
+    }
+
+    protected ExecutorService getNonBlockingExecutor() {
+        return mNonBlockingExecutor;
+    }
 
     /**
      * Performs an HTTP request with the given parameters.

--- a/src/main/java/com/android/volley/toolbox/AsyncHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/AsyncHttpStack.java
@@ -73,10 +73,12 @@ public abstract class AsyncHttpStack extends BaseHttpStack {
         mBlockingExecutor = executor;
     }
 
+    /** Gets blocking executor to perform any potentially blocking tasks. */
     protected ExecutorService getBlockingExecutor() {
         return mBlockingExecutor;
     }
 
+    /** Gets non-blocking executor to perform any non-blocking tasks. */
     protected ExecutorService getNonBlockingExecutor() {
         return mNonBlockingExecutor;
     }

--- a/src/main/java/com/android/volley/toolbox/AsyncHttpStack.java
+++ b/src/main/java/com/android/volley/toolbox/AsyncHttpStack.java
@@ -57,14 +57,14 @@ public abstract class AsyncHttpStack extends BaseHttpStack {
      * This method sets the non blocking executor to be used by the stack for non-blocking tasks.
      * This method must be called before executing any requests.
      */
-    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
+    @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
     public abstract void setNonBlockingExecutor(ExecutorService executor);
 
     /**
      * This method sets the blocking executor to be used by the stack for potentially blocking
      * tasks. This method must be called before executing any requests.
      */
-    @RestrictTo({RestrictTo.Scope.SUBCLASSES, RestrictTo.Scope.LIBRARY_GROUP})
+    @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
     public abstract void setBlockingExecutor(ExecutorService executor);
 
     /**

--- a/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
@@ -146,7 +146,7 @@ public class BasicAsyncNetwork extends AsyncNetwork {
         final long requestStartMs = SystemClock.elapsedRealtime();
         // Gather headers.
         final Map<String, String> additionalRequestHeaders =
-                NetworkUtility.getCacheHeaders(request.getCacheEntry());
+                HttpHeaderParser.getCacheHeaders(request.getCacheEntry());
         mAsyncStack.executeRequest(
                 request,
                 additionalRequestHeaders,

--- a/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
@@ -32,11 +32,14 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 /** A network performing Volley requests over an {@link HttpStack}. */
 public class BasicAsyncNetwork extends AsyncNetwork {
 
     protected final ByteArrayPool mPool;
+
+    protected ExecutorService mBlockingExecutor;
 
     /**
      * @param httpStack HTTP stack to be used
@@ -139,6 +142,7 @@ public class BasicAsyncNetwork extends AsyncNetwork {
 
     @Override
     public void performRequest(final Request<?> request, final OnRequestComplete callback) {
+        mBlockingExecutor = getBlockingExecutor();
         if (mBlockingExecutor == null) {
             throw new IllegalStateException(
                     "mBlockingExecuter should be set before making a request");

--- a/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
@@ -26,7 +26,6 @@ import com.android.volley.AuthFailureError;
 import com.android.volley.Header;
 import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
-import com.android.volley.ServerError;
 import com.android.volley.VolleyError;
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,13 +64,11 @@ public class BasicAsyncNetwork extends AsyncNetwork {
             return;
         }
 
-        byte[] responseContents;
-        if (httpResponse.getContentLength() == -1) {
+        byte[] responseContents = httpResponse.getContentBytes();
+        if (responseContents == null && httpResponse.getContent() == null) {
             // Add 0 byte response as a way of honestly representing a
             // no-content request.
             responseContents = new byte[0];
-        } else {
-            responseContents = httpResponse.getContentBytes();
         }
 
         if (responseContents != null) {
@@ -103,10 +100,6 @@ public class BasicAsyncNetwork extends AsyncNetwork {
                             onRequestFailed(
                                     request, callback, e, requestStartMs, httpResponse, null);
                             return;
-                        } catch (ServerError serverError) {
-                            // This should never happen since we already check if inputStream is
-                            // null
-                            throw new RuntimeException(serverError);
                         }
                         onResponseRead(
                                 requestStartMs,

--- a/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import static com.android.volley.toolbox.NetworkUtility.logSlowRequests;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import androidx.annotation.Nullable;
+import com.android.volley.AsyncNetwork;
+import com.android.volley.AuthFailureError;
+import com.android.volley.Cache;
+import com.android.volley.Cache.Entry;
+import com.android.volley.ClientError;
+import com.android.volley.Header;
+import com.android.volley.NetworkError;
+import com.android.volley.NetworkResponse;
+import com.android.volley.NoConnectionError;
+import com.android.volley.Request;
+import com.android.volley.RetryPolicy;
+import com.android.volley.ServerError;
+import com.android.volley.TimeoutError;
+import com.android.volley.VolleyError;
+import com.android.volley.VolleyLog;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+/** A network performing Volley requests over an {@link HttpStack}. */
+public class BasicAsyncNetwork extends AsyncNetwork {
+    protected static final boolean DEBUG = VolleyLog.DEBUG;
+
+    private static final int SLOW_REQUEST_THRESHOLD_MS = 3000;
+
+    private static final int DEFAULT_POOL_SIZE = 4096;
+
+    /**
+     * @deprecated Should never have been exposed in the API. This field may be removed in a future
+     *     release of Volley.
+     */
+    @Deprecated protected final HttpStack mHttpStack;
+
+    private final BaseHttpStack mBaseHttpStack;
+
+    protected final ByteArrayPool mPool;
+
+    protected ExecutorService mBlockingExecutor;
+
+    protected final Handler mHandler;
+
+    /**
+     * @param httpStack HTTP stack to be used
+     * @deprecated use {@link #BasicAsyncNetwork(BaseHttpStack)} instead to avoid depending on
+     *     Apache HTTP. This method may be removed in a future release of Volley.
+     */
+    @Deprecated
+    public BasicAsyncNetwork(HttpStack httpStack) {
+        // If a pool isn't passed in, then build a small default pool that will give us a lot of
+        // benefit and not use too much memory.
+        this(httpStack, new ByteArrayPool(DEFAULT_POOL_SIZE));
+    }
+
+    /**
+     * @param httpStack HTTP stack to be used
+     * @param pool a buffer pool that improves GC performance in copy operations
+     * @deprecated use {@link #BasicAsyncNetwork(BaseHttpStack, ByteArrayPool)} instead to avoid
+     *     depending on Apache HTTP. This method may be removed in a future release of Volley.
+     */
+    @Deprecated
+    public BasicAsyncNetwork(HttpStack httpStack, ByteArrayPool pool) {
+        mHttpStack = httpStack;
+        mBaseHttpStack = new AdaptedHttpStack(httpStack);
+        mPool = pool;
+        mHandler = null;
+    }
+
+    /** @param httpStack HTTP stack to be used */
+    public BasicAsyncNetwork(BaseHttpStack httpStack) {
+        // If a pool isn't passed in, then build a small default pool that will give us a lot of
+        // benefit and not use too much memory.
+        this(httpStack, new ByteArrayPool(DEFAULT_POOL_SIZE));
+    }
+
+    /**
+     * @param httpStack HTTP stack to be used
+     * @param pool a buffer pool that improves GC performance in copy operations
+     */
+    public BasicAsyncNetwork(BaseHttpStack httpStack, ByteArrayPool pool) {
+        mBaseHttpStack = httpStack;
+        // Populate mHttpStack for backwards compatibility, since it is a protected field. However,
+        // we won't use it directly here, so clients which don't access it directly won't need to
+        // depend on Apache HTTP.
+        mHttpStack = httpStack;
+        mPool = pool;
+        mHandler = new Handler(Looper.myLooper());
+    }
+
+    /* Method to be called after a successful network request */
+    private void onRequestSucceeded(
+            final Request<?> request,
+            final long requestStartMs,
+            final HttpResponse httpResponse,
+            final OnRequestComplete callback) {
+        final int statusCode = httpResponse.getStatusCode();
+        final List<Header> responseHeaders = httpResponse.getHeaders();
+        // Handle cache validation.
+        if (statusCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+            Entry entry = request.getCacheEntry();
+            if (entry == null) {
+                callback.onSuccess(
+                        new NetworkResponse(
+                                HttpURLConnection.HTTP_NOT_MODIFIED,
+                                /* data= */ null,
+                                /* notModified= */ true,
+                                SystemClock.elapsedRealtime() - requestStartMs,
+                                responseHeaders));
+                return;
+            }
+            // Combine cached and response headers so the response will be complete.
+            List<Header> combinedHeaders = NetworkUtility.combineHeaders(responseHeaders, entry);
+            callback.onSuccess(
+                    new NetworkResponse(
+                            HttpURLConnection.HTTP_NOT_MODIFIED,
+                            entry.data,
+                            /* notModified= */ true,
+                            SystemClock.elapsedRealtime() - requestStartMs,
+                            combinedHeaders));
+            return;
+        }
+
+        byte[] responseContents = httpResponse.getContentBytes();
+
+        if (responseContents == null) {
+            final InputStream inputStream = httpResponse.getContent();
+            if (inputStream == null) {
+                // Add 0 byte response as a way of honestly representing a
+                // no-content request.
+                responseContents = new byte[0];
+            } else {
+                Runnable run =
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                PoolingByteArrayOutputStream bytes =
+                                        new PoolingByteArrayOutputStream(
+                                                mPool, httpResponse.getContentLength());
+                                byte[] buffer = new byte[1024];
+                                int count = 0;
+                                while (true) {
+                                    try {
+                                        if ((count = inputStream.read(buffer)) == -1) break;
+                                    } catch (IOException e) {
+                                        onRequestFailed(
+                                                request,
+                                                callback,
+                                                e,
+                                                requestStartMs,
+                                                httpResponse,
+                                                bytes.toByteArray());
+                                    }
+                                    bytes.write(buffer, 0, count);
+                                }
+                                byte[] finalResponseContents = bytes.toByteArray();
+                                runAfterBytesReceived(
+                                        requestStartMs,
+                                        statusCode,
+                                        httpResponse,
+                                        request,
+                                        callback,
+                                        responseHeaders,
+                                        finalResponseContents);
+                            }
+                        };
+                mBlockingExecutor.execute(run);
+                return;
+            }
+        }
+        runAfterBytesReceived(
+                requestStartMs,
+                statusCode,
+                httpResponse,
+                request,
+                callback,
+                responseHeaders,
+                responseContents);
+    }
+
+    /* Method to be called after a failed network request */
+    private void onRequestFailed(
+            Request<?> request,
+            OnRequestComplete callback,
+            IOException exception,
+            long requestStartMs,
+            @Nullable HttpResponse httpResponse,
+            @Nullable byte[] responseContents) {
+        if (exception instanceof SocketTimeoutException) {
+            attemptRetryOnException("socket", request, callback, new TimeoutError());
+        } else if (exception instanceof MalformedURLException) {
+            throw new RuntimeException("Bad URL " + request.getUrl(), exception);
+        } else {
+            int statusCode;
+            if (httpResponse != null) {
+                statusCode = httpResponse.getStatusCode();
+            } else {
+                if (request.shouldRetryConnectionErrors()) {
+                    attemptRetryOnException(
+                            "connection", request, callback, new NoConnectionError());
+                } else {
+                    callback.onError(new NoConnectionError(exception));
+                }
+                return;
+            }
+            VolleyLog.e("Unexpected response code %d for %s", statusCode, request.getUrl());
+            NetworkResponse networkResponse;
+            if (responseContents != null) {
+                List<Header> responseHeaders;
+                responseHeaders = httpResponse.getHeaders();
+                networkResponse =
+                        new NetworkResponse(
+                                statusCode,
+                                responseContents,
+                                /* notModified= */ false,
+                                SystemClock.elapsedRealtime() - requestStartMs,
+                                responseHeaders);
+                if (statusCode == HttpURLConnection.HTTP_UNAUTHORIZED
+                        || statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
+                    attemptRetryOnException(
+                            "auth", request, callback, new AuthFailureError(networkResponse));
+                } else if (statusCode >= 400 && statusCode <= 499) {
+                    // Don't retry other client errors.
+                    callback.onError(new ClientError(networkResponse));
+                } else if (statusCode >= 500 && statusCode <= 599) {
+                    if (request.shouldRetryServerErrors()) {
+                        attemptRetryOnException(
+                                "server", request, callback, new ServerError(networkResponse));
+                    } else {
+                        callback.onError(new ServerError(networkResponse));
+                    }
+                } else {
+                    // 3xx? No reason to retry.
+                    callback.onError(new ServerError(networkResponse));
+                }
+            } else {
+                attemptRetryOnException("network", request, callback, new NetworkError());
+            }
+        }
+    }
+
+    @Override
+    public void performRequest(final Request<?> request, final OnRequestComplete callback) {
+        if (mBlockingExecutor == null) {
+            throw new IllegalStateException();
+        }
+        final long requestStartMs = SystemClock.elapsedRealtime();
+        // Gather headers.
+        Map<String, String> additionalRequestHeaders = getCacheHeaders(request.getCacheEntry());
+        if (mBaseHttpStack instanceof AsyncHttpStack) {
+            AsyncHttpStack asyncStack = (AsyncHttpStack) mBaseHttpStack;
+            asyncStack.executeRequest(
+                    request,
+                    additionalRequestHeaders,
+                    new AsyncHttpStack.OnRequestComplete() {
+                        @Override
+                        public void onSuccess(HttpResponse httpResponse) {
+                            onRequestSucceeded(request, requestStartMs, httpResponse, callback);
+                        }
+
+                        @Override
+                        public void onAuthError(AuthFailureError authFailureError) {
+                            callback.onError(authFailureError);
+                        }
+
+                        @Override
+                        public void onError(IOException ioException) {
+                            onRequestFailed(
+                                    request, callback, ioException, requestStartMs, null, null);
+                        }
+                    });
+        } else {
+            try {
+                onRequestSucceeded(
+                        request,
+                        requestStartMs,
+                        mBaseHttpStack.executeRequest(request, additionalRequestHeaders),
+                        callback);
+            } catch (AuthFailureError e) {
+                callback.onError(e);
+            } catch (IOException e) {
+                onRequestFailed(request, callback, e, requestStartMs, null, null);
+            }
+        }
+    }
+
+    /**
+     * This method sets the non blocking executor to be used by the stack for non-blocking tasks. If
+     * you are not using an {@link com.android.volley.toolbox.AsyncHttpStack}, this should do
+     * nothing. This method must be called before performing any requests if you are using an
+     * AsyncHttpStack.
+     */
+    @Override
+    public void setNonBlockingExecutorForStack(ExecutorService executor) {
+        if (mBaseHttpStack instanceof AsyncHttpStack) {
+            AsyncHttpStack stack = (AsyncHttpStack) mBaseHttpStack;
+            stack.setNonBlockingExecutor(executor);
+        }
+    }
+
+    /**
+     * This method sets the blocking executor to be used by the network and stack for potentially
+     * blocking tasks. This method must be called before performing any requests. Only set the
+     * executor for the stack if it is an instance of {@link
+     * com.android.volley.toolbox.AsyncHttpStack}
+     */
+    @Override
+    public void setBlockingExecutor(ExecutorService executor) {
+        mBlockingExecutor = executor;
+        if (mBaseHttpStack instanceof AsyncHttpStack) {
+            AsyncHttpStack stack = (AsyncHttpStack) mBaseHttpStack;
+            stack.setNonBlockingExecutor(executor);
+        }
+    }
+
+    /**
+     * Attempts to prepare the request for a retry. If there are no more attempts remaining in the
+     * request's retry policy, a timeout exception is thrown.
+     *
+     * @param request The request to use.
+     */
+    private void attemptRetryOnException(
+            final String logPrefix,
+            final Request<?> request,
+            final OnRequestComplete callback,
+            final VolleyError exception) {
+        final RetryPolicy retryPolicy = request.getRetryPolicy();
+        final int oldTimeout = request.getTimeoutMs();
+
+        try {
+            retryPolicy.retry(exception);
+        } catch (VolleyError e) {
+            request.addMarker(
+                    String.format("%s-timeout-giveup [timeout=%s]", logPrefix, oldTimeout));
+            callback.onError(e);
+            return;
+        }
+        request.addMarker(String.format("%s-retry [timeout=%s]", logPrefix, oldTimeout));
+        // If we are using an async stack, then perform retry after a timeout.
+        if (mBaseHttpStack instanceof AsyncHttpStack) {
+            mHandler.postDelayed(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            performRequest(request, callback);
+                        }
+                    },
+                    100);
+        } else {
+            performRequest(request, callback);
+        }
+    }
+
+    private Map<String, String> getCacheHeaders(Cache.Entry entry) {
+        // If there's no cache entry, we're done.
+        if (entry == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> headers = new HashMap<>();
+
+        if (entry.etag != null) {
+            headers.put("If-None-Match", entry.etag);
+        }
+
+        if (entry.lastModified > 0) {
+            headers.put(
+                    "If-Modified-Since", HttpHeaderParser.formatEpochAsRfc1123(entry.lastModified));
+        }
+
+        return headers;
+    }
+
+    /* Helper method that determines what to do after byte[] is received */
+    private void runAfterBytesReceived(
+            long requestStartMs,
+            int statusCode,
+            HttpResponse httpResponse,
+            Request<?> request,
+            OnRequestComplete callback,
+            List<Header> responseHeaders,
+            byte[] responseContents) {
+        // if the request is slow, log it.
+        long requestLifetime = SystemClock.elapsedRealtime() - requestStartMs;
+        logSlowRequests(requestLifetime, request, responseContents, statusCode);
+
+        if (statusCode < 200 || statusCode > 299) {
+            onRequestFailed(
+                    request,
+                    callback,
+                    new IOException(),
+                    requestStartMs,
+                    httpResponse,
+                    responseContents);
+        }
+
+        callback.onSuccess(
+                new NetworkResponse(
+                        statusCode,
+                        responseContents,
+                        /* notModified= */ false,
+                        SystemClock.elapsedRealtime() - requestStartMs,
+                        responseHeaders));
+    }
+}

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -100,7 +100,7 @@ public class BasicNetwork implements Network {
             try {
                 // Gather headers.
                 Map<String, String> additionalRequestHeaders =
-                        NetworkUtility.getCacheHeaders(request.getCacheEntry());
+                        HttpHeaderParser.getCacheHeaders(request.getCacheEntry());
                 httpResponse = mBaseHttpStack.executeRequest(request, additionalRequestHeaders);
                 int statusCode = httpResponse.getStatusCode();
 

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -18,7 +18,6 @@ package com.android.volley.toolbox;
 
 import android.os.SystemClock;
 import com.android.volley.AuthFailureError;
-import com.android.volley.Cache;
 import com.android.volley.Cache.Entry;
 import com.android.volley.ClientError;
 import com.android.volley.Header;
@@ -38,7 +37,6 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -111,7 +109,7 @@ public class BasicNetwork implements Network {
             try {
                 // Gather headers.
                 Map<String, String> additionalRequestHeaders =
-                        getCacheHeaders(request.getCacheEntry());
+                        NetworkUtility.getCacheHeaders(request.getCacheEntry());
                 httpResponse = mBaseHttpStack.executeRequest(request, additionalRequestHeaders);
                 int statusCode = httpResponse.getStatusCode();
 
@@ -233,31 +231,6 @@ public class BasicNetwork implements Network {
             throw e;
         }
         request.addMarker(String.format("%s-retry [timeout=%s]", logPrefix, oldTimeout));
-    }
-
-    private Map<String, String> getCacheHeaders(Cache.Entry entry) {
-        // If there's no cache entry, we're done.
-        if (entry == null) {
-            return Collections.emptyMap();
-        }
-
-        Map<String, String> headers = new HashMap<>();
-
-        if (entry.etag != null) {
-            headers.put("If-None-Match", entry.etag);
-        }
-
-        if (entry.lastModified > 0) {
-            headers.put(
-                    "If-Modified-Since", HttpHeaderParser.formatEpochAsRfc1123(entry.lastModified));
-        }
-
-        return headers;
-    }
-
-    protected void logError(String what, String url, long start) {
-        long now = SystemClock.elapsedRealtime();
-        VolleyLog.v("HTTP ERROR(%s) %d ms to fetch %s", what, (now - start), url);
     }
 
     /** Reads the contents of an InputStream into a byte[]. */

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -139,7 +139,13 @@ public class BasicNetwork implements Network {
                         responseHeaders);
             } catch (IOException e) {
                 NetworkUtility.handleException(
-                        request, null, e, requestStart, httpResponse, responseContents, this);
+                        request,
+                        /* callback= */ null,
+                        e,
+                        requestStart,
+                        httpResponse,
+                        responseContents,
+                        this);
             }
         }
     }

--- a/src/main/java/com/android/volley/toolbox/NetworkUtility.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkUtility.java
@@ -84,15 +84,11 @@ public final class NetworkUtility {
     }
 
     /** Reads the contents of an InputStream into a byte[]. */
-    static byte[] inputStreamToBytes(
-            @Nullable InputStream in, int contentLength, ByteArrayPool pool)
-            throws IOException, ServerError {
+    static byte[] inputStreamToBytes(InputStream in, int contentLength, ByteArrayPool pool)
+            throws IOException {
         PoolingByteArrayOutputStream bytes = new PoolingByteArrayOutputStream(pool, contentLength);
         byte[] buffer = null;
         try {
-            if (in == null) {
-                throw new ServerError();
-            }
             buffer = pool.getBuf(1024);
             int count;
             while ((count = in.read(buffer)) != -1) {

--- a/src/main/java/com/android/volley/toolbox/NetworkUtility.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkUtility.java
@@ -21,6 +21,8 @@ import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.VolleyLog;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,5 +110,25 @@ public class NetworkUtility {
                     statusCode,
                     request.getRetryPolicy().getCurrentRetryCount());
         }
+    }
+
+    static Map<String, String> getCacheHeaders(Cache.Entry entry) {
+        // If there's no cache entry, we're done.
+        if (entry == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> headers = new HashMap<>();
+
+        if (entry.etag != null) {
+            headers.put("If-None-Match", entry.etag);
+        }
+
+        if (entry.lastModified > 0) {
+            headers.put(
+                    "If-Modified-Since", HttpHeaderParser.formatEpochAsRfc1123(entry.lastModified));
+        }
+
+        return headers;
     }
 }

--- a/src/main/java/com/android/volley/toolbox/NetworkUtility.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkUtility.java
@@ -219,6 +219,10 @@ public class NetworkUtility {
         }
     }
 
+    /*
+     * Based on the exception thrown, decides whether to attempt to retry, or to throw the error.
+     * Also handles logging.
+     */
     static void handleException(
             Request<?> request,
             @Nullable AsyncNetwork.OnRequestComplete callback,

--- a/src/main/java/com/android/volley/toolbox/NetworkUtility.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkUtility.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import com.android.volley.Cache;
+import com.android.volley.Header;
+import com.android.volley.Request;
+import com.android.volley.VolleyLog;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+/**
+ * Utility class for methods that are shared between {@link BasicNetwork} and {@link
+ * BasicAsyncNetwork}
+ */
+public class NetworkUtility {
+    protected static final boolean DEBUG = VolleyLog.DEBUG;
+
+    private static final int SLOW_REQUEST_THRESHOLD_MS = 3000;
+    /**
+     * Converts Headers[] to Map&lt;String, String&gt;.
+     *
+     * @deprecated Should never have been exposed in the API. This method may be removed in a future
+     *     release of Volley.
+     */
+    @Deprecated
+    static Map<String, String> convertHeaders(Header[] headers) {
+        Map<String, String> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (int i = 0; i < headers.length; i++) {
+            result.put(headers[i].getName(), headers[i].getValue());
+        }
+        return result;
+    }
+
+    /**
+     * Combine cache headers with network response headers for an HTTP 304 response.
+     *
+     * <p>An HTTP 304 response does not have all header fields. We have to use the header fields
+     * from the cache entry plus the new ones from the response. See also:
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5
+     *
+     * @param responseHeaders Headers from the network response.
+     * @param entry The cached response.
+     * @return The combined list of headers.
+     */
+    static List<Header> combineHeaders(List<Header> responseHeaders, Cache.Entry entry) {
+        // First, create a case-insensitive set of header names from the network
+        // response.
+        Set<String> headerNamesFromNetworkResponse = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        if (!responseHeaders.isEmpty()) {
+            for (Header header : responseHeaders) {
+                headerNamesFromNetworkResponse.add(header.getName());
+            }
+        }
+
+        // Second, add headers from the cache entry to the network response as long as
+        // they didn't appear in the network response, which should take precedence.
+        List<Header> combinedHeaders = new ArrayList<>(responseHeaders);
+        if (entry.allResponseHeaders != null) {
+            if (!entry.allResponseHeaders.isEmpty()) {
+                for (Header header : entry.allResponseHeaders) {
+                    if (!headerNamesFromNetworkResponse.contains(header.getName())) {
+                        combinedHeaders.add(header);
+                    }
+                }
+            }
+        } else {
+            // Legacy caches only have entry.responseHeaders.
+            if (!entry.responseHeaders.isEmpty()) {
+                for (Map.Entry<String, String> header : entry.responseHeaders.entrySet()) {
+                    if (!headerNamesFromNetworkResponse.contains(header.getKey())) {
+                        combinedHeaders.add(new Header(header.getKey(), header.getValue()));
+                    }
+                }
+            }
+        }
+        return combinedHeaders;
+    }
+
+    /** Logs requests that took over SLOW_REQUEST_THRESHOLD_MS to complete. */
+    static void logSlowRequests(
+            long requestLifetime, Request<?> request, byte[] responseContents, int statusCode) {
+        if (DEBUG || requestLifetime > SLOW_REQUEST_THRESHOLD_MS) {
+            VolleyLog.d(
+                    "HTTP response for request=<%s> [lifetime=%d], [size=%s], "
+                            + "[rc=%d], [retryCount=%s]",
+                    request,
+                    requestLifetime,
+                    responseContents != null ? responseContents.length : "null",
+                    statusCode,
+                    request.getRetryPolicy().getCurrentRetryCount());
+        }
+    }
+}

--- a/src/test/java/com/android/volley/mock/MockAsyncStack.java
+++ b/src/test/java/com/android/volley/mock/MockAsyncStack.java
@@ -23,7 +23,6 @@ import com.android.volley.toolbox.HttpResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 
 public class MockAsyncStack extends AsyncHttpStack {
 
@@ -83,15 +82,5 @@ public class MockAsyncStack extends AsyncHttpStack {
             mLastPostBody = null;
         }
         callback.onSuccess(mResponseToReturn);
-    }
-
-    @Override
-    public void setNonBlockingExecutor(ExecutorService executor) {
-        // do nothing
-    }
-
-    @Override
-    public void setBlockingExecutor(ExecutorService executor) {
-        // do nothing
     }
 }

--- a/src/test/java/com/android/volley/mock/MockAsyncStack.java
+++ b/src/test/java/com/android/volley/mock/MockAsyncStack.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.mock;
+
+import com.android.volley.AuthFailureError;
+import com.android.volley.Request;
+import com.android.volley.toolbox.AsyncHttpStack;
+import com.android.volley.toolbox.HttpResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+public class MockAsyncStack extends AsyncHttpStack {
+
+    private HttpResponse mResponseToReturn;
+
+    private IOException mExceptionToThrow;
+
+    private String mLastUrl;
+
+    private Map<String, String> mLastHeaders;
+
+    private byte[] mLastPostBody;
+
+    public String getLastUrl() {
+        return mLastUrl;
+    }
+
+    public Map<String, String> getLastHeaders() {
+        return mLastHeaders;
+    }
+
+    public byte[] getLastPostBody() {
+        return mLastPostBody;
+    }
+
+    public void setResponseToReturn(HttpResponse response) {
+        mResponseToReturn = response;
+    }
+
+    public void setExceptionToThrow(IOException exception) {
+        mExceptionToThrow = exception;
+    }
+
+    @Override
+    public void executeRequest(
+            Request<?> request, Map<String, String> additionalHeaders, OnRequestComplete callback) {
+        if (mExceptionToThrow != null) {
+            callback.onError(mExceptionToThrow);
+            return;
+        }
+        mLastUrl = request.getUrl();
+        mLastHeaders = new HashMap<>();
+        try {
+            if (request.getHeaders() != null) {
+                mLastHeaders.putAll(request.getHeaders());
+            }
+        } catch (AuthFailureError authFailureError) {
+            callback.onAuthError(authFailureError);
+            return;
+        }
+        if (additionalHeaders != null) {
+            mLastHeaders.putAll(additionalHeaders);
+        }
+        try {
+            mLastPostBody = request.getBody();
+        } catch (AuthFailureError e) {
+            mLastPostBody = null;
+        }
+        callback.onSuccess(mResponseToReturn);
+    }
+
+    @Override
+    public void setNonBlockingExecutor(ExecutorService executor) {
+        // do nothing
+    }
+
+    @Override
+    public void setBlockingExecutor(ExecutorService executor) {
+        // do nothing
+    }
+}

--- a/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
@@ -39,6 +39,7 @@ import com.android.volley.ServerError;
 import com.android.volley.TimeoutError;
 import com.android.volley.VolleyError;
 import com.android.volley.mock.MockAsyncStack;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -58,13 +59,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.android.util.concurrent.*;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(sdk = 16)
 public class BasicAsyncNetworkTest {
 
     @Mock private RetryPolicy mMockRetryPolicy;
-    private ExecutorService executor = new RoboExecutorService();
+    private ExecutorService executor = MoreExecutors.newDirectExecutorService();
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
@@ -64,9 +64,8 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class BasicAsyncNetworkTest {
 
-    CompletableFuture<NetworkResponse> future = new CompletableFuture<>();
     @Mock private RetryPolicy mMockRetryPolicy;
-    @Mock AsyncNetwork.OnRequestComplete mockCallback;
+    @Mock private AsyncNetwork.OnRequestComplete mockCallback;
     private ExecutorService executor = MoreExecutors.newDirectExecutorService();
 
     @Before

--- a/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
@@ -59,10 +59,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 16)
 public class BasicAsyncNetworkTest {
 
     @Mock private RetryPolicy mMockRetryPolicy;

--- a/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.android.volley.AsyncNetwork;
+import com.android.volley.AuthFailureError;
+import com.android.volley.Cache.Entry;
+import com.android.volley.Header;
+import com.android.volley.NetworkResponse;
+import com.android.volley.NoConnectionError;
+import com.android.volley.Request;
+import com.android.volley.Response;
+import com.android.volley.RetryPolicy;
+import com.android.volley.ServerError;
+import com.android.volley.TimeoutError;
+import com.android.volley.VolleyError;
+import com.android.volley.mock.MockAsyncStack;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class BasicAsyncNetworkTest {
+
+    @Mock private Request<String> mMockRequest;
+    @Mock private RetryPolicy mMockRetryPolicy;
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+    }
+
+    @Test
+    public void headersAndPostParams() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        HttpResponse fakeResponse =
+                new HttpResponse(
+                        200,
+                        Collections.<Header>emptyList(),
+                        "foobar".getBytes(StandardCharsets.UTF_8));
+        mockAsyncStack.setResponseToReturn(fakeResponse);
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        Entry entry = new Entry();
+        entry.etag = "foobar";
+        entry.lastModified = 1503102002000L;
+        request.setCacheEntry(entry);
+        perform(request, httpNetwork).get();
+        assertEquals("foo", mockAsyncStack.getLastHeaders().get("requestheader"));
+        assertEquals("foobar", mockAsyncStack.getLastHeaders().get("If-None-Match"));
+        assertEquals(
+                "Sat, 19 Aug 2017 00:20:02 GMT",
+                mockAsyncStack.getLastHeaders().get("If-Modified-Since"));
+        assertEquals(
+                "requestpost=foo&",
+                new String(mockAsyncStack.getLastPostBody(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void headersAndPostParamsStream() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        ByteArrayInputStream stream = new ByteArrayInputStream("foobar".getBytes("UTF-8"));
+        HttpResponse fakeResponse =
+                new HttpResponse(200, Collections.<Header>emptyList(), 6, stream);
+        mockAsyncStack.setResponseToReturn(fakeResponse);
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        Entry entry = new Entry();
+        entry.etag = "foobar";
+        entry.lastModified = 1503102002000L;
+        request.setCacheEntry(entry);
+        perform(request, httpNetwork).get();
+        assertEquals("foo", mockAsyncStack.getLastHeaders().get("requestheader"));
+        assertEquals("foobar", mockAsyncStack.getLastHeaders().get("If-None-Match"));
+        assertEquals(
+                "Sat, 19 Aug 2017 00:20:02 GMT",
+                mockAsyncStack.getLastHeaders().get("If-Modified-Since"));
+        assertEquals(
+                "requestpost=foo&",
+                new String(mockAsyncStack.getLastPostBody(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void notModified() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        List<Header> headers = new ArrayList<>();
+        headers.add(new Header("ServerKeyA", "ServerValueA"));
+        headers.add(new Header("ServerKeyB", "ServerValueB"));
+        headers.add(new Header("SharedKey", "ServerValueShared"));
+        headers.add(new Header("sharedcaseinsensitivekey", "ServerValueShared1"));
+        headers.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
+        HttpResponse fakeResponse = new HttpResponse(HttpURLConnection.HTTP_NOT_MODIFIED, headers);
+        mockAsyncStack.setResponseToReturn(fakeResponse);
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        Entry entry = new Entry();
+        entry.allResponseHeaders = new ArrayList<>();
+        entry.allResponseHeaders.add(new Header("CachedKeyA", "CachedValueA"));
+        entry.allResponseHeaders.add(new Header("CachedKeyB", "CachedValueB"));
+        entry.allResponseHeaders.add(new Header("SharedKey", "CachedValueShared"));
+        entry.allResponseHeaders.add(new Header("SHAREDCASEINSENSITIVEKEY", "CachedValueShared1"));
+        entry.allResponseHeaders.add(new Header("shAREDcaSEinSENSITIVEkeY", "CachedValueShared2"));
+        request.setCacheEntry(entry);
+        NetworkResponse response = perform(request, httpNetwork).get();
+        List<Header> expectedHeaders = new ArrayList<>();
+        // Should have all server headers + cache headers that didn't show up in server response.
+        expectedHeaders.add(new Header("ServerKeyA", "ServerValueA"));
+        expectedHeaders.add(new Header("ServerKeyB", "ServerValueB"));
+        expectedHeaders.add(new Header("SharedKey", "ServerValueShared"));
+        expectedHeaders.add(new Header("sharedcaseinsensitivekey", "ServerValueShared1"));
+        expectedHeaders.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
+        expectedHeaders.add(new Header("CachedKeyA", "CachedValueA"));
+        expectedHeaders.add(new Header("CachedKeyB", "CachedValueB"));
+        assertThat(expectedHeaders, containsInAnyOrder(response.allHeaders.toArray(new Header[0])));
+    }
+
+    @Test
+    public void notModified_legacyCache() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        List<Header> headers = new ArrayList<>();
+        headers.add(new Header("ServerKeyA", "ServerValueA"));
+        headers.add(new Header("ServerKeyB", "ServerValueB"));
+        headers.add(new Header("SharedKey", "ServerValueShared"));
+        headers.add(new Header("sharedcaseinsensitivekey", "ServerValueShared1"));
+        headers.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
+        HttpResponse fakeResponse = new HttpResponse(HttpURLConnection.HTTP_NOT_MODIFIED, headers);
+        mockAsyncStack.setResponseToReturn(fakeResponse);
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        Entry entry = new Entry();
+        entry.responseHeaders = new HashMap<>();
+        entry.responseHeaders.put("CachedKeyA", "CachedValueA");
+        entry.responseHeaders.put("CachedKeyB", "CachedValueB");
+        entry.responseHeaders.put("SharedKey", "CachedValueShared");
+        entry.responseHeaders.put("SHAREDCASEINSENSITIVEKEY", "CachedValueShared1");
+        entry.responseHeaders.put("shAREDcaSEinSENSITIVEkeY", "CachedValueShared2");
+        request.setCacheEntry(entry);
+        NetworkResponse response = httpNetwork.performRequest(request);
+        List<Header> expectedHeaders = new ArrayList<>();
+        // Should have all server headers + cache headers that didn't show up in server response.
+        expectedHeaders.add(new Header("ServerKeyA", "ServerValueA"));
+        expectedHeaders.add(new Header("ServerKeyB", "ServerValueB"));
+        expectedHeaders.add(new Header("SharedKey", "ServerValueShared"));
+        expectedHeaders.add(new Header("sharedcaseinsensitivekey", "ServerValueShared1"));
+        expectedHeaders.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
+        expectedHeaders.add(new Header("CachedKeyA", "CachedValueA"));
+        expectedHeaders.add(new Header("CachedKeyB", "CachedValueB"));
+        assertThat(expectedHeaders, containsInAnyOrder(response.allHeaders.toArray(new Header[0])));
+    }
+
+    @Test
+    public void socketTimeout() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        mockAsyncStack.setExceptionToThrow(new SocketTimeoutException());
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        request.setRetryPolicy(mMockRetryPolicy);
+        doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+        perform(request, httpNetwork).get();
+        // should retry socket timeouts
+        verify(mMockRetryPolicy).retry(any(TimeoutError.class));
+    }
+
+    @Test
+    public void noConnectionDefault() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        mockAsyncStack.setExceptionToThrow(new IOException());
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        request.setRetryPolicy(mMockRetryPolicy);
+        doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+        perform(request, httpNetwork).get();
+        // should not retry when there is no connection
+        verify(mMockRetryPolicy, never()).retry(any(VolleyError.class));
+    }
+
+    @Test
+    public void noConnectionRetry() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        mockAsyncStack.setExceptionToThrow(new IOException());
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        request.setRetryPolicy(mMockRetryPolicy);
+        request.setShouldRetryConnectionErrors(true);
+        doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+        perform(request, httpNetwork).get();
+        // should retry when there is no connection
+        verify(mMockRetryPolicy).retry(any(NoConnectionError.class));
+        reset(mMockRetryPolicy);
+    }
+
+    @Test
+    public void noConnectionNoRetry() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        mockAsyncStack.setExceptionToThrow(new IOException());
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        request.setRetryPolicy(mMockRetryPolicy);
+        request.setShouldRetryConnectionErrors(false);
+        doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+        perform(request, httpNetwork).get();
+        // should not retry when there is no connection
+        verify(mMockRetryPolicy, never()).retry(any(VolleyError.class));
+    }
+
+    @Test
+    public void unauthorized() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        HttpResponse fakeResponse = new HttpResponse(401, Collections.<Header>emptyList());
+        mockAsyncStack.setResponseToReturn(fakeResponse);
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        request.setRetryPolicy(mMockRetryPolicy);
+        doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+        perform(request, httpNetwork).get();
+        // should retry in case it's an auth failure.
+        verify(mMockRetryPolicy).retry(any(AuthFailureError.class));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void malformedUrlRequest() throws VolleyError, ExecutionException, InterruptedException {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        mockAsyncStack.setExceptionToThrow(new MalformedURLException());
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        request.setRetryPolicy(mMockRetryPolicy);
+        doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+        perform(request, httpNetwork).get();
+    }
+
+    @Test
+    public void forbidden() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        HttpResponse fakeResponse = new HttpResponse(403, Collections.<Header>emptyList());
+        mockAsyncStack.setResponseToReturn(fakeResponse);
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        httpNetwork.setBlockingExecutor(executor);
+        Request<String> request = buildRequest();
+        request.setRetryPolicy(mMockRetryPolicy);
+        doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+        perform(request, httpNetwork).get();
+        // should retry in case it's an auth failure.
+        verify(mMockRetryPolicy).retry(any(AuthFailureError.class));
+    }
+
+    @Test
+    public void redirect() throws Exception {
+        for (int i = 300; i <= 399; i++) {
+            MockAsyncStack mockAsyncStack = new MockAsyncStack();
+            HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
+            mockAsyncStack.setResponseToReturn(fakeResponse);
+            BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+            httpNetwork.setBlockingExecutor(executor);
+            Request<String> request = buildRequest();
+            request.setRetryPolicy(mMockRetryPolicy);
+            doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+            perform(request, httpNetwork).get();
+            // should not retry 300 responses.
+            verify(mMockRetryPolicy, never()).retry(any(VolleyError.class));
+            reset(mMockRetryPolicy);
+        }
+    }
+
+    @Test
+    public void otherClientError() throws Exception {
+        for (int i = 400; i <= 499; i++) {
+            if (i == 401 || i == 403) {
+                // covered above.
+                continue;
+            }
+            MockAsyncStack mockAsyncStack = new MockAsyncStack();
+            HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
+            mockAsyncStack.setResponseToReturn(fakeResponse);
+            BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+            httpNetwork.setBlockingExecutor(executor);
+            Request<String> request = buildRequest();
+            request.setRetryPolicy(mMockRetryPolicy);
+            doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+            perform(request, httpNetwork).get();
+            // should not retry other 400 errors.
+            verify(mMockRetryPolicy, never()).retry(any(VolleyError.class));
+            reset(mMockRetryPolicy);
+        }
+    }
+
+    @Test
+    public void serverError_enableRetries() throws Exception {
+        for (int i = 500; i <= 599; i++) {
+            MockAsyncStack mockAsyncStack = new MockAsyncStack();
+            HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
+            mockAsyncStack.setResponseToReturn(fakeResponse);
+            BasicAsyncNetwork httpNetwork =
+                    new BasicAsyncNetwork(mockAsyncStack, new ByteArrayPool(4096));
+            httpNetwork.setBlockingExecutor(executor);
+            Request<String> request = buildRequest();
+            request.setRetryPolicy(mMockRetryPolicy);
+            request.setShouldRetryServerErrors(true);
+            doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+            perform(request, httpNetwork).get();
+            // should retry all 500 errors
+            verify(mMockRetryPolicy).retry(any(ServerError.class));
+            reset(mMockRetryPolicy);
+        }
+    }
+
+    @Test
+    public void serverError_disableRetries() throws Exception {
+        for (int i = 500; i <= 599; i++) {
+            MockAsyncStack mockAsyncStack = new MockAsyncStack();
+            HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
+            mockAsyncStack.setResponseToReturn(fakeResponse);
+            BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+            httpNetwork.setBlockingExecutor(executor);
+            Request<String> request = buildRequest();
+            request.setRetryPolicy(mMockRetryPolicy);
+            doThrow(new VolleyError()).when(mMockRetryPolicy).retry(any(VolleyError.class));
+            perform(request, httpNetwork).get();
+            // should not retry any 500 error w/ HTTP 500 retries turned off (the default).
+            verify(mMockRetryPolicy, never()).retry(any(VolleyError.class));
+            reset(mMockRetryPolicy);
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void performRequestNeverSetExecutorTest() throws Exception {
+        MockAsyncStack mockAsyncStack = new MockAsyncStack();
+        HttpResponse fakeResponse = new HttpResponse(200, Collections.<Header>emptyList());
+        mockAsyncStack.setResponseToReturn(fakeResponse);
+        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork(mockAsyncStack);
+        Request<String> request = buildRequest();
+        perform(request, httpNetwork).get();
+    }
+
+    /** Helper functions */
+    private CompletableFuture<NetworkResponse> perform(Request<?> request, AsyncNetwork network) {
+        final CompletableFuture<NetworkResponse> future = new CompletableFuture<>();
+        network.performRequest(
+                request,
+                new AsyncNetwork.OnRequestComplete() {
+                    @Override
+                    public void onSuccess(NetworkResponse networkResponse) {
+                        future.complete(networkResponse);
+                    }
+
+                    @Override
+                    public void onError(VolleyError volleyError) {
+                        future.complete(null);
+                    }
+                });
+        return future;
+    }
+
+    private static Request<String> buildRequest() {
+        return new Request<String>(Request.Method.GET, "http://foo", null) {
+
+            @Override
+            protected Response<String> parseNetworkResponse(NetworkResponse response) {
+                return null;
+            }
+
+            @Override
+            protected void deliverResponse(String response) {}
+
+            @Override
+            public Map<String, String> getHeaders() {
+                Map<String, String> result = new HashMap<String, String>();
+                result.put("requestheader", "foo");
+                return result;
+            }
+
+            @Override
+            public Map<String, String> getParams() {
+                Map<String, String> result = new HashMap<String, String>();
+                result.put("requestpost", "foo");
+                return result;
+            }
+        };
+    }
+}

--- a/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
@@ -37,8 +37,6 @@ public class DiskBasedAsyncCacheTest {
 
     private DiskBasedAsyncCache cache;
 
-    private AsyncCache.OnWriteCompleteCallback futureCallback;
-
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Rule public ExpectedException exception = ExpectedException.none();
@@ -46,7 +44,7 @@ public class DiskBasedAsyncCacheTest {
     @Before
     public void setup() throws IOException, ExecutionException, InterruptedException {
         final CompletableFuture<Void> future = new CompletableFuture<>();
-        futureCallback =
+        AsyncCache.OnWriteCompleteCallback futureCallback =
                 new AsyncCache.OnWriteCompleteCallback() {
                     @Override
                     public void onWriteComplete() {


### PR DESCRIPTION
This PR defines the AsyncNetwork class, as well as an implementation in the form of BasicAsyncNetwork. All test cases that were covered for BasicNetwork are covered here as unit tests. Some shared code I put into a NetworkUtility class.

Some open questions/comments:
- BasicAsyncNetworkTest and BasicNetwork share one helper method. Wasn't sure if it was worth adding a shared class to not duplicate code.
- Wasn't totally sure if the handling of timeouts before retry is what we're looking for.
- For this to compile, I had to change AsyncHttpStack's setExecutor methods to require(LIBRARY) instead of also including subgroups. I'm looking into this now, but changed it for the time being. Also, since the RequestQueue doesn't see the stack directly, I have methods in the network set the executors in AsyncHttpStack.