### PR TITLE
Created builder for DiskBasedAsyncCache

### DIFF
--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -179,7 +179,7 @@ public class BasicNetwork implements Network {
                     statusCode = httpResponse.getStatusCode();
                 } else {
                     if (request.shouldRetryConnectionErrors()) {
-                        attemptRetryOnException("connection", request, new NoConnectionError(e));
+                        attemptRetryOnException("no-connection", request, new NoConnectionError(e));
                         continue;
                     } else {
                         throw new NoConnectionError(e);

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -411,8 +411,8 @@ public class DiskBasedAsyncCache extends AsyncCache {
      * the setters.
      */
     public static class Builder {
-        private FileSupplier rootDirectorySupplier;
-        private File rootDirectory;
+        @Nullable private FileSupplier rootDirectorySupplier;
+        @Nullable private File rootDirectory;
         private int maxCacheSizeInBytes;
 
         public Builder() {

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -413,7 +413,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
     public static class Builder {
         @Nullable private FileSupplier rootDirectorySupplier = null;
         @Nullable private File rootDirectory = null;
-        private int maxCacheSizeInBytes = DiskBasedCacheUtility.DEFAULT_DISK_USAGE_BYTES;;
+        private int maxCacheSizeInBytes = DiskBasedCacheUtility.DEFAULT_DISK_USAGE_BYTES;
 
         /**
          * Sets the root directory of the cache. Must be called if {@link

--- a/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
+++ b/src/main/java/com/android/volley/toolbox/DiskBasedAsyncCache.java
@@ -61,7 +61,7 @@ public class DiskBasedAsyncCache extends AsyncCache {
      *
      * @param rootDirectorySupplier The root directory supplier of the cache.
      */
-    private DiskBasedAsyncCache(final FileSupplier rootDirectorySupplier, int maxCacheSizeInBytes) {
+    private DiskBasedAsyncCache(FileSupplier rootDirectorySupplier, int maxCacheSizeInBytes) {
         mRootDirectorySupplier = rootDirectorySupplier;
         mMaxCacheSizeInBytes = maxCacheSizeInBytes;
     }
@@ -411,22 +411,16 @@ public class DiskBasedAsyncCache extends AsyncCache {
      * the setters.
      */
     public static class Builder {
-        @Nullable private FileSupplier rootDirectorySupplier;
-        @Nullable private File rootDirectory;
-        private int maxCacheSizeInBytes;
-
-        public Builder() {
-            rootDirectorySupplier = null;
-            rootDirectory = null;
-            maxCacheSizeInBytes = -1;
-        }
+        @Nullable private FileSupplier rootDirectorySupplier = null;
+        @Nullable private File rootDirectory = null;
+        private int maxCacheSizeInBytes = DiskBasedCacheUtility.DEFAULT_DISK_USAGE_BYTES;;
 
         /**
          * Sets the root directory of the cache. Must be called if {@link
          * Builder#setRootDirectorySupplier(FileSupplier)} is not.
          */
-        public Builder setRootDirectory(File file) {
-            this.rootDirectory = file;
+        public Builder setRootDirectory(File rootDirectory) {
+            this.rootDirectory = rootDirectory;
             return this;
         }
 
@@ -434,8 +428,8 @@ public class DiskBasedAsyncCache extends AsyncCache {
          * Sets the root directory supplier of the cache. Must be called if {@link
          * Builder#setRootDirectory(File)} is not.
          */
-        public Builder setRootDirectorySupplier(FileSupplier fileSupplier) {
-            this.rootDirectorySupplier = fileSupplier;
+        public Builder setRootDirectorySupplier(FileSupplier rootDirectorySupplier) {
+            this.rootDirectorySupplier = rootDirectorySupplier;
             return this;
         }
 
@@ -452,9 +446,6 @@ public class DiskBasedAsyncCache extends AsyncCache {
         public DiskBasedAsyncCache build() {
             if (rootDirectory == null && rootDirectorySupplier == null) {
                 throw new IllegalArgumentException("Must set either file or supplier");
-            }
-            if (maxCacheSizeInBytes == -1) {
-                maxCacheSizeInBytes = DiskBasedCacheUtility.DEFAULT_DISK_USAGE_BYTES;
             }
             if (rootDirectorySupplier == null) {
                 rootDirectorySupplier =

--- a/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
+++ b/src/test/java/com/android/volley/toolbox/DiskBasedAsyncCacheTest.java
@@ -70,7 +70,11 @@ public class DiskBasedAsyncCacheTest {
                     }
                 };
         // Initialize empty cache
-        cache = new DiskBasedAsyncCache(temporaryFolder.getRoot(), MAX_SIZE);
+        cache =
+                new DiskBasedAsyncCache.Builder()
+                        .setRootDirectory(temporaryFolder.getRoot())
+                        .setMaxCacheSizeInBytes(MAX_SIZE)
+                        .build();
         cache.initialize(futureCallback);
         future.get();
     }
@@ -312,7 +316,11 @@ public class DiskBasedAsyncCacheTest {
         Cache.Entry entry = CacheTestUtils.randomData(1023);
         putEntry("key", entry).get();
 
-        final AsyncCache copy = new DiskBasedAsyncCache(temporaryFolder.getRoot(), MAX_SIZE);
+        final AsyncCache copy =
+                new DiskBasedAsyncCache.Builder()
+                        .setRootDirectory(temporaryFolder.getRoot())
+                        .setMaxCacheSizeInBytes(MAX_SIZE)
+                        .build();
         final CompletableFuture<Cache.Entry> getEntry = new CompletableFuture<>();
         copy.initialize(
                 new AsyncCache.OnWriteCompleteCallback() {


### PR DESCRIPTION
I realized that all the same constructors for DiskBasedCache weren't there for DiskBasedAsyncCache. I added a builder to set the FileSupplier and max size. Could also just use the same telescoping scheme as in DiskBasedCache, but figured this was consistent with the rest of the async implementations.