### PR TITLE
AsyncRequestQueue implementation + some tests

### DIFF
--- a/src/main/java/com/android/volley/AsyncRequestQueue.java
+++ b/src/main/java/com/android/volley/AsyncRequestQueue.java
@@ -1,0 +1,558 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.android.volley.AsyncCache.OnGetCompleteCallback;
+import com.android.volley.AsyncNetwork.OnRequestComplete;
+import com.android.volley.Cache.Entry;
+import com.android.volley.toolbox.ThrowingCache;
+import java.net.HttpURLConnection;
+import java.util.Comparator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class AsyncRequestQueue extends RequestQueue {
+    /** Default number of blocking threads to start. */
+    private static final int DEFAULT_BLOCKING_THREAD_POOL_SIZE = 4;
+
+    /** AsyncCache used to retrieve and store responses. Null indicates use of blocking Cache. */
+    @Nullable private final AsyncCache mAsyncCache;
+
+    /** AsyncNetwork used to perform nework requests. */
+    private final AsyncNetwork mNetwork;
+
+    /**
+     * Cache used to retrieve and store responses. Only use if an AsyncCache cannot be provided due
+     * to lower API.
+     */
+    private final Cache mCache;
+
+    /** Executor for non-blocking tasks. */
+    private ExecutorService mNonBlockingExecutor;
+
+    /** Blocking queue to be used to created Executors */
+    private static final PriorityBlockingQueue<Runnable> mBlockingQueue =
+            new PriorityBlockingQueue<>(
+                    11,
+                    new Comparator<Runnable>() {
+                        @Override
+                        public int compare(Runnable r1, Runnable r2) {
+                            // Vanilla runnables are prioritized first, then RequestTasks are
+                            // ordered
+                            // by the underlying Request.
+                            if (r1 instanceof RequestTask) {
+                                if (r2 instanceof RequestTask) {
+                                    return ((RequestTask<?>) r1).compareTo(((RequestTask<?>) r2));
+                                }
+                                return 1;
+                            }
+                            return r2 instanceof RequestTask ? -1 : 0;
+                        }
+                    });
+
+    /**
+     * Executor for blocking tasks.
+     *
+     * <p>Some tasks in handling requests may not be easy to implement in a non-blocking way, such
+     * as reading or parsing the response data. This executor is used to run these tasks.
+     */
+    private ExecutorService mBlockingExecutor;
+
+    /**
+     * This interface may be used by advanced applications to provide custom executors according to
+     * their needs. Apps must create ExecutorServices dynamically given a blocking queue rather than
+     * providing them directly so that Volley can provide a PriorityQueue which will prioritize
+     * requests according to Request#getPriority.
+     */
+    private ExecutorFactory mExecutorFactory;
+
+    /** Manage list of waiting requests and de-duplicate requests with same cache key. */
+    private final WaitingRequestManager mWaitingRequestManager;
+
+    /**
+     * Sets all the variables, but processing does not begin until {@link #start()} is called.
+     *
+     * @param cache to use for persisting responses to disk. If an AsyncCache was provided, then
+     *     this will be a {@link ThrowingCache}
+     * @param network to perform HTTP requests
+     * @param asyncCache to use for persisting responses to disk. May be null to indicate use of
+     *     blocking cache
+     * @param responseDelivery interface for posting responses and errors
+     * @param executorFactory Interface to be used to provide custom executors according to the
+     *     users needs.
+     */
+    private AsyncRequestQueue(
+            Cache cache,
+            AsyncNetwork network,
+            @Nullable AsyncCache asyncCache,
+            ResponseDelivery responseDelivery,
+            @Nullable ExecutorFactory executorFactory) {
+        super(cache, network, 0, responseDelivery);
+        mAsyncCache = asyncCache;
+        mCache = cache;
+        mNetwork = network;
+        mExecutorFactory = executorFactory;
+        mWaitingRequestManager = new WaitingRequestManager(this);
+    }
+
+    /** Sets the executors and initializes the cache. */
+    @Override
+    public void start() {
+        stop(); // Make sure any currently running threads are stopped
+
+        // Create blocking / non-blocking executors and set them in the network and stack.
+        mNonBlockingExecutor = mExecutorFactory.createNonBlockingExecutor(mBlockingQueue);
+        mBlockingExecutor = mExecutorFactory.createBlockingExecutor(mBlockingQueue);
+        mNetwork.setBlockingExecutor(mBlockingExecutor);
+        mNetwork.setNonBlockingExecutor(mNonBlockingExecutor);
+
+        mNonBlockingExecutor.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        // This is intentionally blocking, because we don't want to process any
+                        // requests until the cache is initialized.
+                        if (mAsyncCache != null) {
+                            final CountDownLatch latch = new CountDownLatch(1);
+                            mAsyncCache.initialize(
+                                    new AsyncCache.OnWriteCompleteCallback() {
+                                        @Override
+                                        public void onWriteComplete() {
+                                            latch.countDown();
+                                        }
+                                    });
+                            try {
+                                latch.await();
+                            } catch (InterruptedException e) {
+                                VolleyLog.e(
+                                        e, "Thread was interrupted while initializing the cache.");
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException(e);
+                            }
+                        } else {
+                            mCache.initialize();
+                        }
+                    }
+                });
+    }
+
+    /** Shuts down and nullifies both executors */
+    @Override
+    public void stop() {
+        if (mNonBlockingExecutor != null) {
+            mNonBlockingExecutor.shutdownNow();
+            mNonBlockingExecutor = null;
+        }
+        if (mBlockingExecutor != null) {
+            mBlockingExecutor.shutdownNow();
+            mBlockingExecutor = null;
+        }
+    }
+
+    /** Begins the request by sending it to the Cache or Network. */
+    @Override
+    <T> void beginRequest(Request<T> request) {
+        // If the request is uncacheable, send it over the network.
+        if (request.shouldCache()) {
+            if (mAsyncCache != null) {
+                mNonBlockingExecutor.execute(new CacheTask<>(request));
+            } else {
+                mBlockingExecutor.execute(new CacheTask<>(request));
+            }
+        } else {
+            sendRequestOverNetwork(request);
+        }
+    }
+
+    @Override
+    <T> void sendRequestOverNetwork(Request<T> request) {
+        mNonBlockingExecutor.execute(new NetworkTask<>(request));
+    }
+
+    /** Abstract runnable that's a task to be completed by the RequestQueue. */
+    private abstract static class RequestTask<T> implements Runnable {
+        final Request<T> mRequest;
+
+        RequestTask(Request<T> request) {
+            mRequest = request;
+        }
+
+        @SuppressWarnings("unchecked")
+        public int compareTo(RequestTask<?> other) {
+            return mRequest.compareTo((Request<T>) other.mRequest);
+        }
+    }
+
+    /** Runnable that gets an entry from the cache. */
+    private class CacheTask<T> extends RequestTask<T> {
+        CacheTask(Request<T> request) {
+            super(request);
+        }
+
+        @Override
+        public void run() {
+            // If the request has been canceled, don't bother dispatching it.
+            if (mRequest.isCanceled()) {
+                mRequest.finish("cache-discard-canceled");
+                return;
+            }
+
+            mRequest.addMarker("cache-queue-take");
+
+            // Attempt to retrieve this item from cache.
+            if (mAsyncCache != null) {
+                mAsyncCache.get(
+                        mRequest.getCacheKey(),
+                        new OnGetCompleteCallback() {
+                            @Override
+                            public void onGetComplete(Entry entry) {
+                                handleEntry(entry, mRequest);
+                            }
+                        });
+            } else {
+                Entry entry = mCache.get(mRequest.getCacheKey());
+                handleEntry(entry, mRequest);
+            }
+        }
+    }
+
+    /** Helper method that handles the cache entry after getting it from the Cache. */
+    private void handleEntry(final Entry entry, final Request<?> mRequest) {
+        if (entry == null) {
+            mRequest.addMarker("cache-miss");
+            // Cache miss; send off to the network dispatcher.
+            if (!mWaitingRequestManager.maybeAddToWaitingRequests(mRequest)) {
+                sendRequestOverNetwork(mRequest);
+            }
+            return;
+        }
+
+        // If it is completely expired, just send it to the network.
+        if (entry.isExpired()) {
+            mRequest.addMarker("cache-hit-expired");
+            mRequest.setCacheEntry(entry);
+            if (!mWaitingRequestManager.maybeAddToWaitingRequests(mRequest)) {
+                sendRequestOverNetwork(mRequest);
+            }
+            return;
+        }
+
+        // We have a cache hit; parse its data for delivery back to the request.
+        mBlockingExecutor.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        mRequest.addMarker("cache-hit");
+                        Response<?> response =
+                                mRequest.parseNetworkResponse(
+                                        new NetworkResponse(
+                                                HttpURLConnection.HTTP_OK,
+                                                entry.data,
+                                                /* notModified= */ false,
+                                                /* networkTimeMs= */ 0,
+                                                entry.allResponseHeaders));
+                        mRequest.addMarker("cache-hit-parsed");
+
+                        if (!entry.refreshNeeded()) {
+                            // Completely unexpired cache hit. Just deliver the response.
+                            getResponseDelivery().postResponse(mRequest, response);
+                        } else {
+                            // Soft-expired cache hit. We can deliver the cached response,
+                            // but we need to also send the request to the network for
+                            // refreshing.
+                            mRequest.addMarker("cache-hit-refresh-needed");
+                            mRequest.setCacheEntry(entry);
+                            // Mark the response as intermediate.
+                            response.intermediate = true;
+
+                            if (!mWaitingRequestManager.maybeAddToWaitingRequests(mRequest)) {
+                                // Post the intermediate response back to the user and have
+                                // the delivery then forward the request along to the network.
+                                getResponseDelivery()
+                                        .postResponse(
+                                                mRequest,
+                                                response,
+                                                new Runnable() {
+                                                    @Override
+                                                    public void run() {
+                                                        sendRequestOverNetwork(mRequest);
+                                                    }
+                                                });
+                            } else {
+                                // request has been added to list of waiting requests
+                                // to receive the network response from the first request once it
+                                // returns.
+                                getResponseDelivery().postResponse(mRequest, response);
+                            }
+                        }
+                    }
+                });
+    }
+
+    /** Runnable that performs the network request */
+    private class NetworkTask<T> extends RequestTask<T> {
+        NetworkTask(Request<T> request) {
+            super(request);
+        }
+
+        @Override
+        public void run() {
+            // If the request was cancelled already, do not perform the
+            // network request.
+            if (mRequest.isCanceled()) {
+                mRequest.finish("network-discard-cancelled");
+                mRequest.notifyListenerResponseNotUsable();
+                return;
+            }
+
+            final long startTimeMs = SystemClock.elapsedRealtime();
+            mRequest.addMarker("network-queue-take");
+
+            // TODO: Figure out what to do with traffic stats tags. Can this be pushed to the
+            // HTTP stack, or is it no longer feasible to support?
+
+            // Perform the network request.
+            mNetwork.performRequest(
+                    mRequest,
+                    new OnRequestComplete() {
+                        @Override
+                        public void onSuccess(final NetworkResponse networkResponse) {
+                            mRequest.addMarker("network-http-complete");
+
+                            // If the server returned 304 AND we delivered a response already,
+                            // we're done -- don't deliver a second identical response.
+                            if (networkResponse.notModified && mRequest.hasHadResponseDelivered()) {
+                                mRequest.finish("not-modified");
+                                mRequest.notifyListenerResponseNotUsable();
+                                return;
+                            }
+
+                            // Parse the response here on the worker thread.
+                            mBlockingExecutor.execute(new ParseTask<>(mRequest, networkResponse));
+                        }
+
+                        @Override
+                        public void onError(final VolleyError volleyError) {
+                            volleyError.setNetworkTimeMs(
+                                    SystemClock.elapsedRealtime() - startTimeMs);
+                            mBlockingExecutor.execute(
+                                    new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            VolleyError parsedError =
+                                                    mRequest.parseNetworkError(volleyError);
+                                            getResponseDelivery().postError(mRequest, parsedError);
+                                            mRequest.notifyListenerResponseNotUsable();
+                                        }
+                                    });
+                        }
+                    });
+        }
+    }
+
+    /** Runnable that parses a network response. */
+    private class ParseTask<T> extends RequestTask<T> {
+        NetworkResponse networkResponse;
+
+        ParseTask(Request<T> request, NetworkResponse networkResponse) {
+            super(request);
+            this.networkResponse = networkResponse;
+        }
+
+        @Override
+        public void run() {
+            final Response<?> response = mRequest.parseNetworkResponse(networkResponse);
+            mRequest.addMarker("network-parse-complete");
+
+            // Write to cache if applicable.
+            // TODO: Only update cache metadata instead of entire
+            // record for 304s.
+            if (mRequest.shouldCache() && response.cacheEntry != null) {
+                if (mAsyncCache != null) {
+                    mNonBlockingExecutor.execute(
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    mAsyncCache.put(
+                                            mRequest.getCacheKey(),
+                                            response.cacheEntry,
+                                            new AsyncCache.OnWriteCompleteCallback() {
+                                                @Override
+                                                public void onWriteComplete() {
+                                                    finishRequest(response, true);
+                                                }
+                                            });
+                                }
+                            });
+                } else {
+                    mCache.put(mRequest.getCacheKey(), response.cacheEntry);
+                    finishRequest(response, true);
+                }
+            } else {
+                finishRequest(response, false);
+            }
+        }
+
+        private void finishRequest(Response<?> response, boolean cached) {
+            if (cached) {
+                mRequest.addMarker("network-cache-written");
+            }
+            // Post the response back.
+            mRequest.markDelivered();
+            getResponseDelivery().postResponse(mRequest, response);
+            mRequest.notifyListenerResponseReceived(response);
+        }
+    }
+
+    /**
+     * This interface may be used by advanced applications to provide custom executors according to
+     * their needs. Apps must create ExecutorServices dynamically given a blocking queue rather than
+     * providing them directly so that Volley can provide a PriorityQueue which will prioritize
+     * requests according to Request#getPriority.
+     */
+    public interface ExecutorFactory {
+        ExecutorService createNonBlockingExecutor(BlockingQueue<?> taskQueue);
+
+        ExecutorService createBlockingExecutor(BlockingQueue<?> taskQueue);
+    }
+
+    /**
+     * Builder is used to build an instance of {@link AsyncRequestQueue} from values configured by
+     * the setters.
+     */
+    public static class Builder {
+        private AsyncCache mAsyncCache;
+        private final AsyncNetwork mNetwork;
+        private Cache mCache;
+        private ExecutorFactory mExecutorFactory;
+        private ResponseDelivery mResponseDelivery;
+
+        public Builder(AsyncNetwork asyncNetwork) {
+            if (asyncNetwork == null) {
+                throw new IllegalArgumentException("Network cannot be null");
+            }
+            mNetwork = asyncNetwork;
+            mExecutorFactory = null;
+            mResponseDelivery = new ExecutorDelivery(new Handler(Looper.getMainLooper()));
+            mAsyncCache = null;
+            mCache = null;
+        }
+
+        /**
+         * Sets the executor factory to be used by the AsyncRequestQueue. If this is not called, we
+         * will default to calling getDefaultExecutorFactory.
+         */
+        public Builder setExecutorFactory(ExecutorFactory executorFactory) {
+            mExecutorFactory = executorFactory;
+            return this;
+        }
+
+        /**
+         * Sets the response deliver to be used by the AsyncRequestQueue. If this is not called, we
+         * will default to creating a new {@link ExecutorDelivery} with the applications main
+         * thread.
+         */
+        public Builder setResponseDelivery(ResponseDelivery responseDelivery) {
+            mResponseDelivery = responseDelivery;
+            return this;
+        }
+
+        /** Sets the AsyncCache to be used by the AsyncRequestQueue. */
+        public Builder setAsyncCache(AsyncCache asyncCache) {
+            mAsyncCache = asyncCache;
+            return this;
+        }
+
+        /** Sets the Cache to be used by the AsyncRequestQueue. */
+        public Builder setCache(Cache cache) {
+            mCache = cache;
+            return this;
+        }
+
+        /** Provides a default ExecutorFactory to use, if one is never set. */
+        private ExecutorFactory getDefaultExecutorFactory() {
+            return new ExecutorFactory() {
+                @Override
+                public ExecutorService createNonBlockingExecutor(BlockingQueue<?> taskQueue) {
+                    return new ThreadPoolExecutor(
+                            /* corePoolSize= */ 0,
+                            /* maximumPoolSize= */ 1,
+                            /* keepAliveTime= */ 60,
+                            /* unit= */ TimeUnit.SECONDS,
+                            mBlockingQueue,
+                            new ThreadFactory() {
+                                @Override
+                                public Thread newThread(@NonNull Runnable runnable) {
+                                    Thread t = Executors.defaultThreadFactory().newThread(runnable);
+                                    t.setName("Volley-NonBlockingExecutor");
+                                    return t;
+                                }
+                            });
+                }
+
+                @Override
+                public ExecutorService createBlockingExecutor(BlockingQueue<?> taskQueue) {
+                    return new ThreadPoolExecutor(
+                            /* corePoolSize= */ 0,
+                            /* maximumPoolSize= */ DEFAULT_BLOCKING_THREAD_POOL_SIZE,
+                            /* keepAliveTime= */ 60,
+                            /* unit= */ TimeUnit.SECONDS,
+                            mBlockingQueue,
+                            new ThreadFactory() {
+                                @Override
+                                public Thread newThread(@NonNull Runnable runnable) {
+                                    Thread t = Executors.defaultThreadFactory().newThread(runnable);
+                                    t.setName("Volley-BlockingExecutor");
+                                    return t;
+                                }
+                            });
+                }
+            };
+        }
+
+        public AsyncRequestQueue build() {
+            // If neither cache is set by the caller, throw an illegal argument exception.
+            if (mCache == null && mAsyncCache == null) {
+                throw new IllegalArgumentException("You must set one of the cache objects");
+            }
+            if (mCache == null) {
+                // if no cache is provided, we will provide one that throws
+                // UnsupportedOperationExceptions to pass into the parent class.
+                mCache = new ThrowingCache();
+            }
+            if (mResponseDelivery == null) {
+                mResponseDelivery = new ExecutorDelivery(new Handler(Looper.getMainLooper()));
+            }
+            if (mExecutorFactory == null) {
+                mExecutorFactory = getDefaultExecutorFactory();
+            }
+            return new AsyncRequestQueue(
+                    mCache, mNetwork, mAsyncCache, mResponseDelivery, mExecutorFactory);
+        }
+    }
+}

--- a/src/main/java/com/android/volley/CacheDispatcher.java
+++ b/src/main/java/com/android/volley/CacheDispatcher.java
@@ -18,10 +18,6 @@ package com.android.volley;
 
 import android.os.Process;
 import androidx.annotation.VisibleForTesting;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
 /**
@@ -72,7 +68,7 @@ public class CacheDispatcher extends Thread {
         mNetworkQueue = networkQueue;
         mCache = cache;
         mDelivery = delivery;
-        mWaitingRequestManager = new WaitingRequestManager(this);
+        mWaitingRequestManager = new WaitingRequestManager(this, networkQueue, delivery);
     }
 
     /**
@@ -205,115 +201,6 @@ public class CacheDispatcher extends Thread {
             }
         } finally {
             request.sendEvent(RequestQueue.RequestEvent.REQUEST_CACHE_LOOKUP_FINISHED);
-        }
-    }
-
-    private static class WaitingRequestManager implements Request.NetworkRequestCompleteListener {
-
-        /**
-         * Staging area for requests that already have a duplicate request in flight.
-         *
-         * <ul>
-         *   <li>containsKey(cacheKey) indicates that there is a request in flight for the given
-         *       cache key.
-         *   <li>get(cacheKey) returns waiting requests for the given cache key. The in flight
-         *       request is <em>not</em> contained in that list. Is null if no requests are staged.
-         * </ul>
-         */
-        private final Map<String, List<Request<?>>> mWaitingRequests = new HashMap<>();
-
-        private final CacheDispatcher mCacheDispatcher;
-
-        WaitingRequestManager(CacheDispatcher cacheDispatcher) {
-            mCacheDispatcher = cacheDispatcher;
-        }
-
-        /** Request received a valid response that can be used by other waiting requests. */
-        @Override
-        public void onResponseReceived(Request<?> request, Response<?> response) {
-            if (response.cacheEntry == null || response.cacheEntry.isExpired()) {
-                onNoUsableResponseReceived(request);
-                return;
-            }
-            String cacheKey = request.getCacheKey();
-            List<Request<?>> waitingRequests;
-            synchronized (this) {
-                waitingRequests = mWaitingRequests.remove(cacheKey);
-            }
-            if (waitingRequests != null) {
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.v(
-                            "Releasing %d waiting requests for cacheKey=%s.",
-                            waitingRequests.size(), cacheKey);
-                }
-                // Process all queued up requests.
-                for (Request<?> waiting : waitingRequests) {
-                    mCacheDispatcher.mDelivery.postResponse(waiting, response);
-                }
-            }
-        }
-
-        /** No valid response received from network, release waiting requests. */
-        @Override
-        public synchronized void onNoUsableResponseReceived(Request<?> request) {
-            String cacheKey = request.getCacheKey();
-            List<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
-            if (waitingRequests != null && !waitingRequests.isEmpty()) {
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.v(
-                            "%d waiting requests for cacheKey=%s; resend to network",
-                            waitingRequests.size(), cacheKey);
-                }
-                Request<?> nextInLine = waitingRequests.remove(0);
-                mWaitingRequests.put(cacheKey, waitingRequests);
-                nextInLine.setNetworkRequestCompleteListener(this);
-                try {
-                    mCacheDispatcher.mNetworkQueue.put(nextInLine);
-                } catch (InterruptedException iex) {
-                    VolleyLog.e("Couldn't add request to queue. %s", iex.toString());
-                    // Restore the interrupted status of the calling thread (i.e. NetworkDispatcher)
-                    Thread.currentThread().interrupt();
-                    // Quit the current CacheDispatcher thread.
-                    mCacheDispatcher.quit();
-                }
-            }
-        }
-
-        /**
-         * For cacheable requests, if a request for the same cache key is already in flight, add it
-         * to a queue to wait for that in-flight request to finish.
-         *
-         * @return whether the request was queued. If false, we should continue issuing the request
-         *     over the network. If true, we should put the request on hold to be processed when the
-         *     in-flight request finishes.
-         */
-        private synchronized boolean maybeAddToWaitingRequests(Request<?> request) {
-            String cacheKey = request.getCacheKey();
-            // Insert request into stage if there's already a request with the same cache key
-            // in flight.
-            if (mWaitingRequests.containsKey(cacheKey)) {
-                // There is already a request in flight. Queue up.
-                List<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
-                if (stagedRequests == null) {
-                    stagedRequests = new ArrayList<>();
-                }
-                request.addMarker("waiting-for-response");
-                stagedRequests.add(request);
-                mWaitingRequests.put(cacheKey, stagedRequests);
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.d("Request for cacheKey=%s is in flight, putting on hold.", cacheKey);
-                }
-                return true;
-            } else {
-                // Insert 'null' queue for this cacheKey, indicating there is now a request in
-                // flight.
-                mWaitingRequests.put(cacheKey, null);
-                request.setNetworkRequestCompleteListener(this);
-                if (VolleyLog.DEBUG) {
-                    VolleyLog.d("new request, sending to network %s", cacheKey);
-                }
-                return false;
-            }
         }
     }
 }

--- a/src/main/java/com/android/volley/RequestQueue.java
+++ b/src/main/java/com/android/volley/RequestQueue.java
@@ -263,13 +263,17 @@ public class RequestQueue {
         request.addMarker("add-to-queue");
         sendRequestEvent(request, RequestEvent.REQUEST_QUEUED);
 
+        beginRequest(request);
+        return request;
+    }
+
+    <T> void beginRequest(Request<T> request) {
         // If the request is uncacheable, skip the cache queue and go straight to the network.
         if (!request.shouldCache()) {
-            mNetworkQueue.add(request);
-            return request;
+            sendRequestOverNetwork(request);
+        } else {
+            mCacheQueue.add(request);
         }
-        mCacheQueue.add(request);
-        return request;
     }
 
     /**
@@ -326,5 +330,13 @@ public class RequestQueue {
         synchronized (mFinishedListeners) {
             mFinishedListeners.remove(listener);
         }
+    }
+
+    public ResponseDelivery getResponseDelivery() {
+        return mDelivery;
+    }
+
+    <T> void sendRequestOverNetwork(Request<T> request) {
+        mNetworkQueue.add(request);
     }
 }

--- a/src/main/java/com/android/volley/WaitingRequestManager.java
+++ b/src/main/java/com/android/volley/WaitingRequestManager.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+
+class WaitingRequestManager implements Request.NetworkRequestCompleteListener {
+
+    /**
+     * Staging area for requests that already have a duplicate request in flight.
+     *
+     * <ul>
+     *   <li>containsKey(cacheKey) indicates that there is a request in flight for the given cache
+     *       key.
+     *   <li>get(cacheKey) returns waiting requests for the given cache key. The in flight request
+     *       is <em>not</em> contained in that list. Is null if no requests are staged.
+     * </ul>
+     */
+    private final Map<String, List<Request<?>>> mWaitingRequests = new HashMap<>();
+
+    private final ResponseDelivery mResponseDelivery;
+
+    private final RequestQueue mRequestQueue;
+
+    private final CacheDispatcher mCacheDispatcher;
+    private final BlockingQueue<Request<?>> mNetworkQueue;
+
+    WaitingRequestManager(RequestQueue requestQueue) {
+        mRequestQueue = requestQueue;
+        mResponseDelivery = mRequestQueue.getResponseDelivery();
+        mCacheDispatcher = null;
+        mNetworkQueue = null;
+    }
+
+    WaitingRequestManager(
+            CacheDispatcher cacheDispatcher,
+            BlockingQueue<Request<?>> networkQueue,
+            ResponseDelivery responseDelivery) {
+        mRequestQueue = null;
+        mResponseDelivery = responseDelivery;
+        mCacheDispatcher = cacheDispatcher;
+        mNetworkQueue = networkQueue;
+    }
+
+    /** Request received a valid response that can be used by other waiting requests. */
+    @Override
+    public void onResponseReceived(Request<?> request, Response<?> response) {
+        if (response.cacheEntry == null || response.cacheEntry.isExpired()) {
+            onNoUsableResponseReceived(request);
+            return;
+        }
+        String cacheKey = request.getCacheKey();
+        List<Request<?>> waitingRequests;
+        synchronized (this) {
+            waitingRequests = mWaitingRequests.remove(cacheKey);
+        }
+        if (waitingRequests != null) {
+            if (VolleyLog.DEBUG) {
+                VolleyLog.v(
+                        "Releasing %d waiting requests for cacheKey=%s.",
+                        waitingRequests.size(), cacheKey);
+            }
+            // Process all queued up requests.
+            for (Request<?> waiting : waitingRequests) {
+                mResponseDelivery.postResponse(waiting, response);
+            }
+        }
+    }
+
+    /** No valid response received from network, release waiting requests. */
+    @Override
+    public synchronized void onNoUsableResponseReceived(Request<?> request) {
+        String cacheKey = request.getCacheKey();
+        List<Request<?>> waitingRequests = mWaitingRequests.remove(cacheKey);
+        if (waitingRequests != null && !waitingRequests.isEmpty()) {
+            if (VolleyLog.DEBUG) {
+                VolleyLog.v(
+                        "%d waiting requests for cacheKey=%s; resend to network",
+                        waitingRequests.size(), cacheKey);
+            }
+            Request<?> nextInLine = waitingRequests.remove(0);
+            mWaitingRequests.put(cacheKey, waitingRequests);
+            nextInLine.setNetworkRequestCompleteListener(this);
+            if (mRequestQueue != null) {
+                mRequestQueue.sendRequestOverNetwork(nextInLine);
+            } else {
+                try {
+                    mNetworkQueue.put(nextInLine);
+                } catch (InterruptedException iex) {
+                    VolleyLog.e("Couldn't add request to queue. %s", iex.toString());
+                    // Restore the interrupted status of the calling thread (i.e. NetworkDispatcher)
+                    Thread.currentThread().interrupt();
+                    // Quit the current CacheDispatcher thread.
+                    mCacheDispatcher.quit();
+                }
+            }
+        }
+    }
+
+    /**
+     * For cacheable requests, if a request for the same cache key is already in flight, add it to a
+     * queue to wait for that in-flight request to finish.
+     *
+     * @return whether the request was queued. If false, we should continue issuing the request over
+     *     the network. If true, we should put the request on hold to be processed when the
+     *     in-flight request finishes.
+     */
+    synchronized boolean maybeAddToWaitingRequests(Request<?> request) {
+        String cacheKey = request.getCacheKey();
+        // Insert request into stage if there's already a request with the same cache key
+        // in flight.
+        if (mWaitingRequests.containsKey(cacheKey)) {
+            // There is already a request in flight. Queue up.
+            List<Request<?>> stagedRequests = mWaitingRequests.get(cacheKey);
+            if (stagedRequests == null) {
+                stagedRequests = new ArrayList<>();
+            }
+            request.addMarker("waiting-for-response");
+            stagedRequests.add(request);
+            mWaitingRequests.put(cacheKey, stagedRequests);
+            if (VolleyLog.DEBUG) {
+                VolleyLog.d("Request for cacheKey=%s is in flight, putting on hold.", cacheKey);
+            }
+            return true;
+        } else {
+            // Insert 'null' queue for this cacheKey, indicating there is now a request in
+            // flight.
+            mWaitingRequests.put(cacheKey, null);
+            request.setNetworkRequestCompleteListener(this);
+            if (VolleyLog.DEBUG) {
+                VolleyLog.d("new request, sending to network %s", cacheKey);
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/android/volley/toolbox/ThrowingCache.java
+++ b/src/main/java/com/android/volley/toolbox/ThrowingCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley.toolbox;
+
+import com.android.volley.Cache;
+
+/** A cache that thorws an error if a method is called. */
+public class ThrowingCache implements Cache {
+    @Override
+    public Entry get(String key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void put(String key, Entry entry) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void initialize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void invalidate(String key, boolean fullExpire) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void remove(String key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/com/android/volley/AsyncRequestQueueTest.java
+++ b/src/test/java/com/android/volley/AsyncRequestQueueTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.volley;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.android.volley.mock.ShadowSystemClock;
+import com.android.volley.toolbox.NoCache;
+import com.android.volley.toolbox.StringRequest;
+import com.android.volley.utils.ImmediateResponseDelivery;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/** Unit tests for RequestQueue, with all dependencies mocked out */
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows = {ShadowSystemClock.class})
+public class AsyncRequestQueueTest {
+
+    private ResponseDelivery mDelivery;
+    @Mock private AsyncNetwork mMockNetwork;
+
+    @Before
+    public void setUp() throws Exception {
+        mDelivery = new ImmediateResponseDelivery();
+        initMocks(this);
+    }
+
+    @Test
+    public void cancelAll_onlyCorrectTag() throws Exception {
+        AsyncRequestQueue queue =
+                new AsyncRequestQueue.Builder(mMockNetwork)
+                        .setCache(new NoCache())
+                        .setResponseDelivery(mDelivery)
+                        .build();
+        queue.start();
+        Object tagA = new Object();
+        Object tagB = new Object();
+        StringRequest req1 = mock(StringRequest.class);
+        when(req1.getTag()).thenReturn(tagA);
+        StringRequest req2 = mock(StringRequest.class);
+        when(req2.getTag()).thenReturn(tagB);
+        StringRequest req3 = mock(StringRequest.class);
+        when(req3.getTag()).thenReturn(tagA);
+        StringRequest req4 = mock(StringRequest.class);
+        when(req4.getTag()).thenReturn(tagA);
+
+        queue.add(req1); // A
+        queue.add(req2); // B
+        queue.add(req3); // A
+        queue.cancelAll(tagA);
+        queue.add(req4); // A
+
+        verify(req1).cancel(); // A cancelled
+        verify(req3).cancel(); // A cancelled
+        verify(req2, never()).cancel(); // B not cancelled
+        verify(req4, never()).cancel(); // A added after cancel not cancelled
+        queue.stop();
+    }
+
+    @Test
+    public void add_notifiesListener() throws Exception {
+        RequestQueue.RequestEventListener listener = mock(RequestQueue.RequestEventListener.class);
+        AsyncRequestQueue queue =
+                new AsyncRequestQueue.Builder(mMockNetwork)
+                        .setCache(new NoCache())
+                        .setResponseDelivery(mDelivery)
+                        .build();
+        queue.start();
+        queue.addRequestEventListener(listener);
+        StringRequest req = mock(StringRequest.class);
+
+        queue.add(req);
+
+        verify(listener).onRequestEvent(req, RequestQueue.RequestEvent.REQUEST_QUEUED);
+        verifyNoMoreInteractions(listener);
+        queue.stop();
+    }
+
+    @Test
+    public void finish_notifiesListener() throws Exception {
+        RequestQueue.RequestEventListener listener = mock(RequestQueue.RequestEventListener.class);
+        AsyncRequestQueue queue =
+                new AsyncRequestQueue.Builder(mMockNetwork)
+                        .setCache(new NoCache())
+                        .setResponseDelivery(mDelivery)
+                        .build();
+        queue.start();
+        queue.addRequestEventListener(listener);
+        StringRequest req = mock(StringRequest.class);
+
+        queue.finish(req);
+
+        verify(listener).onRequestEvent(req, RequestQueue.RequestEvent.REQUEST_FINISHED);
+        verifyNoMoreInteractions(listener);
+        queue.stop();
+    }
+
+    @Test
+    public void sendRequestEvent_notifiesListener() throws Exception {
+        StringRequest req = mock(StringRequest.class);
+        RequestQueue.RequestEventListener listener = mock(RequestQueue.RequestEventListener.class);
+        AsyncRequestQueue queue =
+                new AsyncRequestQueue.Builder(mMockNetwork)
+                        .setCache(new NoCache())
+                        .setResponseDelivery(mDelivery)
+                        .build();
+        queue.start();
+        queue.addRequestEventListener(listener);
+
+        queue.sendRequestEvent(req, RequestQueue.RequestEvent.REQUEST_NETWORK_DISPATCH_STARTED);
+
+        verify(listener)
+                .onRequestEvent(req, RequestQueue.RequestEvent.REQUEST_NETWORK_DISPATCH_STARTED);
+        verifyNoMoreInteractions(listener);
+        queue.stop();
+    }
+
+    @Test
+    public void removeRequestEventListener_removesListener() throws Exception {
+        StringRequest req = mock(StringRequest.class);
+        RequestQueue.RequestEventListener listener = mock(RequestQueue.RequestEventListener.class);
+        AsyncRequestQueue queue =
+                new AsyncRequestQueue.Builder(mMockNetwork)
+                        .setCache(new NoCache())
+                        .setResponseDelivery(mDelivery)
+                        .build();
+        queue.start();
+        queue.addRequestEventListener(listener);
+        queue.removeRequestEventListener(listener);
+
+        queue.sendRequestEvent(req, RequestQueue.RequestEvent.REQUEST_NETWORK_DISPATCH_STARTED);
+
+        verifyNoMoreInteractions(listener);
+        queue.stop();
+    }
+}


### PR DESCRIPTION
Implementation for AsyncRequestQueue. Overrides start / stop / sendRequestOverNetwork. add was changed in RequestQueue to now invoke beginTask which is overridden in AsyncRequestQueue. WaitingRequestManager was to its own class so that both CacheDispatcher and AsyncRequestQueue can use it. (From what I can tell, that doesn't break any APIs).

Currently it handles either a cache or asyncCache and branches depending on which is being used.

One thing that I noticed was different than the current requestQueue is that start() must be called before adding requests. This is because the executors are null until we call start(). Not sure if this matters, and if it does, where we should be initializing the executors.

I tried to copy the RequestQueue.Test to AsyncRequestQueue.Test. Not sure if there are other unit tests we should be doing for this. I also tested on test app and it seems to be working based on that.

I didn't add the newAsyncRequestQueue() method in Volley.java into this PR. Wasn't sure if we should wait for that, but I have code written for that if we want to add that too.