### PR TITLE
Provide a ScheduledExecutorService to AsyncRequestQueue/AsyncNetwork.

### DIFF
--- a/src/main/java/com/android/volley/AsyncNetwork.java
+++ b/src/main/java/com/android/volley/AsyncNetwork.java
@@ -20,6 +20,7 @@ import androidx.annotation.RestrictTo;
 import com.android.volley.toolbox.AsyncHttpStack;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** An asynchronous implementation of {@link Network} to perform requests. */
@@ -27,6 +28,7 @@ public abstract class AsyncNetwork implements Network {
     private final AsyncHttpStack mAsyncStack;
     private ExecutorService mBlockingExecutor;
     private ExecutorService mNonBlockingExecutor;
+    private ScheduledExecutorService mNonBlockingScheduledExecutor;
 
     protected AsyncNetwork(AsyncHttpStack stack) {
         mAsyncStack = stack;
@@ -113,6 +115,15 @@ public abstract class AsyncNetwork implements Network {
         mAsyncStack.setBlockingExecutor(executor);
     }
 
+    /**
+     * This method sets the scheduled executor to be used by the network and stack for non-blocking
+     * tasks to be scheduled. This method must be called before performing any requests.
+     */
+    @RestrictTo({RestrictTo.Scope.LIBRARY_GROUP})
+    public void setNonBlockingScheduledExecutor(ScheduledExecutorService executor) {
+        mNonBlockingScheduledExecutor = executor;
+    }
+
     /** Gets blocking executor to perform any potentially blocking tasks. */
     protected ExecutorService getBlockingExecutor() {
         return mBlockingExecutor;
@@ -121,6 +132,11 @@ public abstract class AsyncNetwork implements Network {
     /** Gets non-blocking executor to perform any non-blocking tasks. */
     protected ExecutorService getNonBlockingExecutor() {
         return mNonBlockingExecutor;
+    }
+
+    /** Gets scheduled executor to perform any non-blocking tasks that need to be scheduled. */
+    protected ScheduledExecutorService getNonBlockingScheduledExecutor() {
+        return mNonBlockingScheduledExecutor;
     }
 
     /** Gets the {@link AsyncHttpStack} to be used by the network. */

--- a/src/test/java/com/android/volley/AsyncRequestQueueTest.java
+++ b/src/test/java/com/android/volley/AsyncRequestQueueTest.java
@@ -30,6 +30,7 @@ import com.android.volley.utils.ImmediateResponseDelivery;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +44,7 @@ import org.robolectric.annotation.Config;
 public class AsyncRequestQueueTest {
 
     @Mock private AsyncNetwork mMockNetwork;
+    @Mock private ScheduledExecutorService mMockScheduledExecutor;
     private AsyncRequestQueue queue;
 
     @Before
@@ -65,6 +67,12 @@ public class AsyncRequestQueueTest {
                                     public ExecutorService createBlockingExecutor(
                                             BlockingQueue<Runnable> taskQueue) {
                                         return MoreExecutors.newDirectExecutorService();
+                                    }
+
+                                    @Override
+                                    public ScheduledExecutorService
+                                            createNonBlockingScheduledExecutor() {
+                                        return mMockScheduledExecutor;
                                     }
                                 })
                         .build();


### PR DESCRIPTION
This is a subset of #363 which ensures a ScheduledExecutorService is available,
but does not yet define a new RetryPolicy interface. This gives us the
flexibility to introduce timer-based operations later without needing to change
the ExecutorFactory interface (which is now an abstract class to allow for future
additions, should any others be necessary).