### PR TITLE
Add cURL logging support to CronetHttpStack.

### DIFF
--- a/src/test/java/com/android/volley/cronet/CronetHttpStackTest.java
+++ b/src/test/java/com/android/volley/cronet/CronetHttpStackTest.java
@@ -17,15 +17,328 @@
 package com.android.volley.cronet;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.android.volley.Header;
+import com.android.volley.cronet.CronetHttpStack.CurlCommandLogger;
+import com.android.volley.mock.TestRequest;
+import com.android.volley.toolbox.AsyncHttpStack.OnRequestComplete;
+import com.android.volley.toolbox.UrlRewriter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import org.chromium.net.CronetEngine;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 
+@RunWith(RobolectricTestRunner.class)
 public class CronetHttpStackTest {
+    @Mock private CurlCommandLogger mMockCurlCommandLogger;
+    @Mock private OnRequestComplete mMockOnRequestComplete;
+    @Mock private UrlRewriter mMockUrlRewriter;
+
+    // A fake would be ideal here, but Cronet doesn't (yet) provide one, and at the moment we aren't
+    // exercising the full response flow.
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private CronetEngine mMockCronetEngine;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void curlLogging_disabled() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                // Default parameters should not enable cURL logging.
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.Get(), ImmutableMap.<String, String>of(), mMockOnRequestComplete);
+
+        verify(mMockCurlCommandLogger, never()).logCurlCommand(anyString());
+    }
+
+    @Test
+    public void curlLogging_simpleTextRequest() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true);
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.Get(), ImmutableMap.<String, String>of(), mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        assertEquals("curl -X GET \"http://foo.com\"", curlCommandCaptor.getValue());
+    }
+
+    @Test
+    public void curlLogging_rewrittenUrl() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true)
+                                        .setUrlRewriter(mMockUrlRewriter);
+                            }
+                        });
+        when(mMockUrlRewriter.rewriteUrl("http://foo.com")).thenReturn("http://bar.com");
+
+        stack.executeRequest(
+                new TestRequest.Get(), ImmutableMap.<String, String>of(), mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        assertEquals("curl -X GET \"http://bar.com\"", curlCommandCaptor.getValue());
+    }
+
+    @Test
+    public void curlLogging_headers_withoutTokens() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true);
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.Delete() {
+                    @Override
+                    public Map<String, String> getHeaders() {
+                        return ImmutableMap.of(
+                                "SomeHeader", "SomeValue",
+                                "Authorization", "SecretToken");
+                    }
+                },
+                ImmutableMap.of("SomeOtherHeader", "SomeValue"),
+                mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        // NOTE: Header order is stable because the implementation uses a TreeMap.
+        assertEquals(
+                "curl -X DELETE --header \"Authorization: [REDACTED]\" "
+                        + "--header \"SomeHeader: SomeValue\" "
+                        + "--header \"SomeOtherHeader: SomeValue\" \"http://foo.com\"",
+                curlCommandCaptor.getValue());
+    }
+
+    @Test
+    public void curlLogging_headers_withTokens() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true)
+                                        .setLogAuthTokensInCurlCommands(true);
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.Delete() {
+                    @Override
+                    public Map<String, String> getHeaders() {
+                        return ImmutableMap.of(
+                                "SomeHeader", "SomeValue",
+                                "Authorization", "SecretToken");
+                    }
+                },
+                ImmutableMap.of("SomeOtherHeader", "SomeValue"),
+                mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        // NOTE: Header order is stable because the implementation uses a TreeMap.
+        assertEquals(
+                "curl -X DELETE --header \"Authorization: SecretToken\" "
+                        + "--header \"SomeHeader: SomeValue\" "
+                        + "--header \"SomeOtherHeader: SomeValue\" \"http://foo.com\"",
+                curlCommandCaptor.getValue());
+    }
+
+    @Test
+    public void curlLogging_textRequest() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true);
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.PostWithBody() {
+                    @Override
+                    public byte[] getBody() {
+                        try {
+                            return "hello".getBytes("UTF-8");
+                        } catch (UnsupportedEncodingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    @Override
+                    public String getBodyContentType() {
+                        return "text/plain; charset=UTF-8";
+                    }
+                },
+                ImmutableMap.<String, String>of(),
+                mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        // TODO: This output is unexpected because it is using the binary format and missing the
+        // Content-Type header. Fix the test along with the bug in CronetHttpStack.
+        assertEquals(
+                "echo 'aGVsbG8=' | base64 -d > /tmp/$$.bin; curl -X POST \"http://foo.com\" "
+                        + "--data-binary @/tmp/$$.bin",
+                curlCommandCaptor.getValue());
+    }
+
+    @Test
+    public void curlLogging_gzipTextRequest() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true);
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.PostWithBody() {
+                    @Override
+                    public byte[] getBody() {
+                        return new byte[] {1, 2, 3, 4, 5};
+                    }
+
+                    @Override
+                    public String getBodyContentType() {
+                        return "text/plain";
+                    }
+
+                    @Override
+                    public Map<String, String> getHeaders() {
+                        return ImmutableMap.of("Content-Encoding", "gzip, identity");
+                    }
+                },
+                ImmutableMap.<String, String>of(),
+                mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        // TODO: This output is unexpected because it is missing the Content-Type header. Fix the
+        // test along with the bug in CronetHttpStack.
+        assertEquals(
+                "echo 'AQIDBAU=' | base64 -d > /tmp/$$.bin; curl -X POST "
+                        + "--header \"Content-Encoding: gzip, identity\" \"http://foo.com\" "
+                        + "--data-binary @/tmp/$$.bin",
+                curlCommandCaptor.getValue());
+    }
+
+    @Test
+    public void curlLogging_binaryRequest() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true);
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.PostWithBody() {
+                    @Override
+                    public byte[] getBody() {
+                        return new byte[] {1, 2, 3, 4, 5};
+                    }
+
+                    @Override
+                    public String getBodyContentType() {
+                        return "application/octet-stream";
+                    }
+                },
+                ImmutableMap.<String, String>of(),
+                mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        // TODO: This output is unexpected because it is missing the Content-Type header. Fix the
+        // test along with the bug in CronetHttpStack.
+        assertEquals(
+                "echo 'AQIDBAU=' | base64 -d > /tmp/$$.bin; curl -X POST \"http://foo.com\" "
+                        + "--data-binary @/tmp/$$.bin",
+                curlCommandCaptor.getValue());
+    }
+
+    @Test
+    public void curlLogging_largeRequest() {
+        CronetHttpStack stack =
+                createStack(
+                        new Consumer<CronetHttpStack.Builder>() {
+                            @Override
+                            public void accept(CronetHttpStack.Builder builder) {
+                                builder.setCurlLoggingEnabled(true);
+                            }
+                        });
+
+        stack.executeRequest(
+                new TestRequest.PostWithBody() {
+                    @Override
+                    public byte[] getBody() {
+                        return new byte[2048];
+                    }
+
+                    @Override
+                    public String getBodyContentType() {
+                        return "application/octet-stream";
+                    }
+                },
+                ImmutableMap.<String, String>of(),
+                mMockOnRequestComplete);
+
+        ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
+        // TODO: This output is unexpected because it is missing the Content-Type header. Fix the
+        // test along with the bug in CronetHttpStack.
+        assertEquals(
+                "curl -X POST \"http://foo.com\" [REQUEST BODY TOO LARGE TO INCLUDE]",
+                curlCommandCaptor.getValue());
+    }
+
     @Test
     public void getHeadersEmptyTest() {
         List<Map.Entry<String, String>> list = new ArrayList<>();
@@ -55,5 +368,17 @@ public class CronetHttpStackTest {
             assertEquals(expected.get(i).getName(), actual.get(i).getName());
             assertEquals(expected.get(i).getValue(), actual.get(i).getValue());
         }
+    }
+
+    private CronetHttpStack createStack(Consumer<CronetHttpStack.Builder> stackEditor) {
+        CronetHttpStack.Builder builder =
+                new CronetHttpStack.Builder(RuntimeEnvironment.application)
+                        .setCronetEngine(mMockCronetEngine)
+                        .setCurlCommandLogger(mMockCurlCommandLogger);
+        stackEditor.accept(builder);
+        CronetHttpStack stack = builder.build();
+        stack.setBlockingExecutor(MoreExecutors.newDirectExecutorService());
+        stack.setNonBlockingExecutor(MoreExecutors.newDirectExecutorService());
+        return stack;
     }
 }


### PR DESCRIPTION
For debugging purposes, applications may ask Volley to log an
equivalent cURL command for any requests being issued through
this HTTP stack.

Some caveats/notes:

- UrlRequest (and UrlRequest.Builder) don't provide getters for
  the parameters we set on them, and they can't be trivially
  read from the Request either. So we introduce an internal
  container class, CurlLoggedRequestParameters, to store any
  parameters that we want to both propagate to the UrlRequest as
  well as include in cURL logging when enabled. This still isn't
  perfect - Cronet may append additional request headers of its
  own, such as user agent. But this should work as a close
  approximation, and there doesn't appear to be a better way.

- By default, we attempt to redact any auth tokens by redacting
  the values of Authorization and Cookie headers, while providing
  an option to bypass this if needed.

- We have a crude heuristic to detect text vs. binary content so
  that known text content can be logged in plaintext when passed
  to cURL. It's certainly not complete, but for debugging purposes
  it should suffice for now.

- CronetHttpStack has a bug compared to HurlStack where it fails to
  set the Content-Type header when there is a request body. Some test
  output is expected to change once this bug is resolved.