### PR TITLE
Set Content-Type header for requests with bodies.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/src/main/java/com/android/volley/toolbox/HttpHeaderParser.java
@@ -17,6 +17,8 @@
 package com.android.volley.toolbox;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.RestrictTo.Scope;
 import com.android.volley.Cache;
 import com.android.volley.Header;
 import com.android.volley.NetworkResponse;
@@ -38,7 +40,8 @@ import java.util.TreeSet;
 /** Utility methods for parsing HTTP headers. */
 public class HttpHeaderParser {
 
-    static final String HEADER_CONTENT_TYPE = "Content-Type";
+    @RestrictTo({Scope.LIBRARY_GROUP})
+    public static final String HEADER_CONTENT_TYPE = "Content-Type";
 
     private static final String DEFAULT_CONTENT_CHARSET = "ISO-8859-1";
 

--- a/src/test/java/com/android/volley/cronet/CronetHttpStackTest.java
+++ b/src/test/java/com/android/volley/cronet/CronetHttpStackTest.java
@@ -218,11 +218,10 @@ public class CronetHttpStackTest {
 
         ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
         verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
-        // TODO: This output is unexpected because it is using the binary format and missing the
-        // Content-Type header. Fix the test along with the bug in CronetHttpStack.
         assertEquals(
-                "echo 'aGVsbG8=' | base64 -d > /tmp/$$.bin; curl -X POST \"http://foo.com\" "
-                        + "--data-binary @/tmp/$$.bin",
+                "curl -X POST "
+                        + "--header \"Content-Type: text/plain; charset=UTF-8\" \"http://foo.com\" "
+                        + "--data-ascii \"hello\"",
                 curlCommandCaptor.getValue());
     }
 
@@ -259,11 +258,10 @@ public class CronetHttpStackTest {
 
         ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
         verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
-        // TODO: This output is unexpected because it is missing the Content-Type header. Fix the
-        // test along with the bug in CronetHttpStack.
         assertEquals(
                 "echo 'AQIDBAU=' | base64 -d > /tmp/$$.bin; curl -X POST "
-                        + "--header \"Content-Encoding: gzip, identity\" \"http://foo.com\" "
+                        + "--header \"Content-Encoding: gzip, identity\" "
+                        + "--header \"Content-Type: text/plain\" \"http://foo.com\" "
                         + "--data-binary @/tmp/$$.bin",
                 curlCommandCaptor.getValue());
     }
@@ -296,10 +294,9 @@ public class CronetHttpStackTest {
 
         ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
         verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
-        // TODO: This output is unexpected because it is missing the Content-Type header. Fix the
-        // test along with the bug in CronetHttpStack.
         assertEquals(
-                "echo 'AQIDBAU=' | base64 -d > /tmp/$$.bin; curl -X POST \"http://foo.com\" "
+                "echo 'AQIDBAU=' | base64 -d > /tmp/$$.bin; curl -X POST "
+                        + "--header \"Content-Type: application/octet-stream\" \"http://foo.com\" "
                         + "--data-binary @/tmp/$$.bin",
                 curlCommandCaptor.getValue());
     }
@@ -332,10 +329,10 @@ public class CronetHttpStackTest {
 
         ArgumentCaptor<String> curlCommandCaptor = ArgumentCaptor.forClass(String.class);
         verify(mMockCurlCommandLogger).logCurlCommand(curlCommandCaptor.capture());
-        // TODO: This output is unexpected because it is missing the Content-Type header. Fix the
-        // test along with the bug in CronetHttpStack.
         assertEquals(
-                "curl -X POST \"http://foo.com\" [REQUEST BODY TOO LARGE TO INCLUDE]",
+                "curl -X POST "
+                        + "--header \"Content-Type: application/octet-stream\" \"http://foo.com\" "
+                        + "[REQUEST BODY TOO LARGE TO INCLUDE]",
                 curlCommandCaptor.getValue());
     }
 


### PR DESCRIPTION
This is handled by HurlStack#addBody and should be handled in the
Cronet stack as well.