### PR TITLE
Make it possible to extend classes created with Builders.

### DIFF
--- a/src/test/java/com/android/volley/AsyncRequestQueueTest.java
+++ b/src/test/java/com/android/volley/AsyncRequestQueueTest.java
@@ -52,7 +52,7 @@ public class AsyncRequestQueueTest {
         ResponseDelivery mDelivery = new ImmediateResponseDelivery();
         initMocks(this);
         queue =
-                new AsyncRequestQueue.Builder(mMockNetwork)
+                AsyncRequestQueue.builder(mMockNetwork)
                         .setAsyncCache(new NoAsyncCache())
                         .setResponseDelivery(mDelivery)
                         .setExecutorFactory(

--- a/src/test/java/com/android/volley/cronet/CronetHttpStackTest.java
+++ b/src/test/java/com/android/volley/cronet/CronetHttpStackTest.java
@@ -372,7 +372,7 @@ public class CronetHttpStackTest {
 
     private CronetHttpStack createStack(Consumer<CronetHttpStack.Builder> stackEditor) {
         CronetHttpStack.Builder builder =
-                new CronetHttpStack.Builder(RuntimeEnvironment.application)
+                CronetHttpStack.builder(RuntimeEnvironment.application)
                         .setCronetEngine(mMockCronetEngine)
                         .setCurlCommandLogger(mMockCurlCommandLogger);
         stackEditor.accept(builder);

--- a/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
+++ b/src/test/java/com/android/volley/toolbox/BasicAsyncNetworkTest.java
@@ -19,11 +19,11 @@ package com.android.volley.toolbox;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -82,7 +82,7 @@ public class BasicAsyncNetworkTest {
                         Collections.<Header>emptyList(),
                         "foobar".getBytes(StandardCharsets.UTF_8));
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         Entry entry = new Entry();
@@ -107,7 +107,7 @@ public class BasicAsyncNetworkTest {
         HttpResponse fakeResponse =
                 new HttpResponse(200, Collections.<Header>emptyList(), 6, stream);
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         Entry entry = new Entry();
@@ -136,7 +136,7 @@ public class BasicAsyncNetworkTest {
         headers.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
         HttpResponse fakeResponse = new HttpResponse(HttpURLConnection.HTTP_NOT_MODIFIED, headers);
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         Entry entry = new Entry();
@@ -172,7 +172,7 @@ public class BasicAsyncNetworkTest {
         headers.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
         HttpResponse fakeResponse = new HttpResponse(HttpURLConnection.HTTP_NOT_MODIFIED, headers);
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         Entry entry = new Entry();
@@ -200,7 +200,7 @@ public class BasicAsyncNetworkTest {
     public void socketTimeout() throws Exception {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         mockAsyncStack.setExceptionToThrow(new SocketTimeoutException());
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         request.setRetryPolicy(mMockRetryPolicy);
@@ -217,7 +217,7 @@ public class BasicAsyncNetworkTest {
     public void noConnectionDefault() throws Exception {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         mockAsyncStack.setExceptionToThrow(new IOException());
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         request.setRetryPolicy(mMockRetryPolicy);
@@ -234,7 +234,7 @@ public class BasicAsyncNetworkTest {
     public void noConnectionRetry() throws Exception {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         mockAsyncStack.setExceptionToThrow(new IOException());
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         request.setRetryPolicy(mMockRetryPolicy);
@@ -252,7 +252,7 @@ public class BasicAsyncNetworkTest {
     public void noConnectionNoRetry() throws Exception {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         mockAsyncStack.setExceptionToThrow(new IOException());
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         request.setRetryPolicy(mMockRetryPolicy);
@@ -271,7 +271,7 @@ public class BasicAsyncNetworkTest {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         HttpResponse fakeResponse = new HttpResponse(401, Collections.<Header>emptyList());
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         request.setRetryPolicy(mMockRetryPolicy);
@@ -288,7 +288,7 @@ public class BasicAsyncNetworkTest {
     public void malformedUrlRequest() throws VolleyError, ExecutionException, InterruptedException {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         mockAsyncStack.setExceptionToThrow(new MalformedURLException());
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         request.setRetryPolicy(mMockRetryPolicy);
@@ -301,7 +301,7 @@ public class BasicAsyncNetworkTest {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         HttpResponse fakeResponse = new HttpResponse(403, Collections.<Header>emptyList());
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         request.setRetryPolicy(mMockRetryPolicy);
@@ -320,7 +320,7 @@ public class BasicAsyncNetworkTest {
             MockAsyncStack mockAsyncStack = new MockAsyncStack();
             HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
             mockAsyncStack.setResponseToReturn(fakeResponse);
-            BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+            BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
             httpNetwork.setBlockingExecutor(executor);
             Request<String> request = buildRequest();
             request.setRetryPolicy(mMockRetryPolicy);
@@ -349,7 +349,7 @@ public class BasicAsyncNetworkTest {
             MockAsyncStack mockAsyncStack = new MockAsyncStack();
             HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
             mockAsyncStack.setResponseToReturn(fakeResponse);
-            BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+            BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
             httpNetwork.setBlockingExecutor(executor);
             Request<String> request = buildRequest();
             request.setRetryPolicy(mMockRetryPolicy);
@@ -370,7 +370,7 @@ public class BasicAsyncNetworkTest {
             HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
             mockAsyncStack.setResponseToReturn(fakeResponse);
             BasicAsyncNetwork httpNetwork =
-                    new BasicAsyncNetwork.Builder(mockAsyncStack)
+                    BasicAsyncNetwork.builder(mockAsyncStack)
                             .setPool(new ByteArrayPool(4096))
                             .build();
             httpNetwork.setBlockingExecutor(executor);
@@ -393,7 +393,7 @@ public class BasicAsyncNetworkTest {
             MockAsyncStack mockAsyncStack = new MockAsyncStack();
             HttpResponse fakeResponse = new HttpResponse(i, Collections.<Header>emptyList());
             mockAsyncStack.setResponseToReturn(fakeResponse);
-            BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+            BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
             httpNetwork.setBlockingExecutor(executor);
             Request<String> request = buildRequest();
             request.setRetryPolicy(mMockRetryPolicy);
@@ -418,7 +418,7 @@ public class BasicAsyncNetworkTest {
         headers.add(new Header("SharedCaseInsensitiveKey", "ServerValueShared2"));
         HttpResponse fakeResponse = new HttpResponse(HttpURLConnection.HTTP_NOT_MODIFIED, headers);
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         httpNetwork.performRequest(request, mockCallback);
@@ -436,7 +436,7 @@ public class BasicAsyncNetworkTest {
                         Collections.<Header>emptyList(),
                         "foobar".getBytes(StandardCharsets.UTF_8));
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         httpNetwork.setBlockingExecutor(executor);
         Request<String> request = buildRequest();
         Entry entry = new Entry();
@@ -454,7 +454,7 @@ public class BasicAsyncNetworkTest {
         MockAsyncStack mockAsyncStack = new MockAsyncStack();
         HttpResponse fakeResponse = new HttpResponse(200, Collections.<Header>emptyList());
         mockAsyncStack.setResponseToReturn(fakeResponse);
-        BasicAsyncNetwork httpNetwork = new BasicAsyncNetwork.Builder(mockAsyncStack).build();
+        BasicAsyncNetwork httpNetwork = BasicAsyncNetwork.builder(mockAsyncStack).build();
         Request<String> request = buildRequest();
         perform(request, httpNetwork).get();
     }


### PR DESCRIPTION
AsyncRequestQueue, BasicAsyncNetwork, and CronetHttpStack all use a new Builder
pattern to simplify construction. However, they are also all possible to
subclass by design, just like their synchronous counterparts. At the moment,
this is impossible, since the constructor is private, and the Builder class
does not know about subclasses in order to build them.

So, switch to a pattern that permits both Builders and inheritance. Builder
classes are now genericized and can be extended. Each instantiable class
has both a public abstract Builder class for extending and an internal
Builder class for actual creation, which can be accessed with a new
static builder() method. The work in build() has been moved to the
constructor itself to ensure it is invoked for subclasses.

This is a significantly more verbose pattern, but the only other options
would be to revert back to regular constructors, or to try and disallow
subclassing and provide other hooks (e.g. callback interfaces) where
customization is desired. This feels like the best compromise to keep
Volley mostly as it was before, just with some Builders to help with
instantiation.