### PR TITLE
Fix empty responses when content length is unknown.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HttpResponse.java
+++ b/src/main/java/com/android/volley/toolbox/HttpResponse.java
@@ -107,13 +107,12 @@ public final class HttpResponse {
      */
     @Nullable
     public final InputStream getContent() {
-        if (mContentLength == -1) {
-            return null;
-        }
         if (mContent != null) {
             return mContent;
-        } else {
+        } else if (mContentBytes != null) {
             return new ByteArrayInputStream(mContentBytes);
+        } else {
+            return null;
         }
     }
 }


### PR DESCRIPTION
For whatever reason, it seems that HttpUrlConnection#getContentLength may
return -1 even if the response includes a Content-Length header. This
still worked fine in Volley, which only used this header to try to
pre-size buffers for reading the response. However, this regressed when
we introduced the change to HttpResponse to support byte[] content in
addition to InputStream content, as we used the content-length to determine
whether content was expected.

Resolve this regression by just checking that content was provided (in
either form) before returning it, or else returning null, without
requiring a valid Content-Length header to be set.