### PR TITLE
Clean up cache initialization in AsyncRequestQueue.

### DIFF
--- a/src/test/java/com/android/volley/AsyncRequestQueueTest.java
+++ b/src/test/java/com/android/volley/AsyncRequestQueueTest.java
@@ -146,8 +146,9 @@ public class AsyncRequestQueueTest {
 
     @Test
     public void requestsQueuedBeforeCacheInitialization_asyncCache() {
+        // Create a new queue with a mock cache in order to verify the initialization.
         AsyncCache mockAsyncCache = mock(AsyncCache.class);
-        queue = createRequestQueue(mockAsyncCache);
+        AsyncRequestQueue queue = createRequestQueue(mockAsyncCache);
         queue.start();
 
         ArgumentCaptor<OnWriteCompleteCallback> callbackCaptor =


### PR DESCRIPTION
The previous implementation had two key flaws:

- It performed a blocking task in the non-blocking thread pool
- It failed to prevent requests from attempting cache reads prior to
  initialization completing, assuming the relevant thread pool has
  more than one available thread.

To resolve this, we perform initialization asynchronously. Until
it completes, we hold all queued requests in a separate queue.
In practice, initialization should finish quickly, and it should
be rare for this to have any impact on the request flow.

Chained futures would make for a cleaner implementation - we could
store a future tied to initialization and add listeners upon
future completion to begin the request, avoiding the need to track
these requests ourselves and ensure thread safety - but they are
unfortunately not usable in Volley, which only supports Java 7.

Fixes #379