### PR TITLE
fix: fixed hurl volley error

### DIFF
--- a/src/main/java/com/android/volley/toolbox/HurlStack.java
+++ b/src/main/java/com/android/volley/toolbox/HurlStack.java
@@ -217,6 +217,7 @@ public class HurlStack extends BaseHttpStack {
         int timeoutMs = request.getTimeoutMs();
         connection.setConnectTimeout(timeoutMs);
         connection.setReadTimeout(timeoutMs);
+        connection.setChunkedStreamingMode(0);
         connection.setUseCaches(false);
         connection.setDoInput(true);
 


### PR DESCRIPTION
Volley sends data twice if the connection is slow. The line of code added in HurlStack solves that problem