### PR TITLE
Use a consistent timebase when evaluating soft/hard TTLs.

### DIFF
--- a/src/main/java/com/android/volley/Cache.java
+++ b/src/main/java/com/android/volley/Cache.java
@@ -102,12 +102,20 @@ public interface Cache {
 
         /** True if the entry is expired. */
         public boolean isExpired() {
-            return this.ttl < System.currentTimeMillis();
+            return isExpired(System.currentTimeMillis());
+        }
+
+        boolean isExpired(long currentTimeMillis) {
+            return this.ttl < currentTimeMillis;
         }
 
         /** True if a refresh is needed from the original data source. */
         public boolean refreshNeeded() {
-            return this.softTtl < System.currentTimeMillis();
+            return refreshNeeded(System.currentTimeMillis());
+        }
+
+        boolean refreshNeeded(long currentTimeMillis) {
+            return this.softTtl < currentTimeMillis;
         }
     }
 }


### PR DESCRIPTION
Previously, we'd evaluate whether a cache entry was valid per these TTLs using two different checks against the current system time. This could result in a spurious trigger of soft TTL logic if the first time check occurs before the soft TTL expiry but the second occurs after it, and the hard and soft TTL are identical.

Unit tests are omitted since we don't have an easy way to mock the clock with the current architecture. This could be improved in the future.

Fixes #388