### PR TITLE
Invoke RetryPolicy#retry in the blocking executor.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -22,6 +22,7 @@ import com.android.volley.Network;
 import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
 import com.android.volley.VolleyError;
+import com.android.volley.toolbox.NetworkUtility.RetryInfo;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -140,8 +141,11 @@ public class BasicNetwork implements Network {
             } catch (IOException e) {
                 // This will either throw an exception, breaking us from the loop, or will loop
                 // again and retry the request.
-                NetworkUtility.handleException(
-                        request, e, requestStart, httpResponse, responseContents);
+                RetryInfo retryInfo =
+                        NetworkUtility.shouldRetryException(
+                                request, e, requestStart, httpResponse, responseContents);
+                // We should already be on a background thread, so we can invoke the retry inline.
+                NetworkUtility.attemptRetryOnException(request, retryInfo);
             }
         }
     }

--- a/src/main/java/com/android/volley/toolbox/NetworkUtility.java
+++ b/src/main/java/com/android/volley/toolbox/NetworkUtility.java
@@ -196,9 +196,8 @@ public final class NetworkUtility {
                     if (request.shouldRetryServerErrors()) {
                         return new RetryInfo("server", new ServerError(networkResponse));
                     }
-                    throw new ServerError(networkResponse);
                 }
-                // 3xx? No reason to retry.
+                // Server error and client has opted out of retries, or 3xx. No reason to retry.
                 throw new ServerError(networkResponse);
             }
             return new RetryInfo("network", new NetworkError());


### PR DESCRIPTION
When using the synchronous RequestQueue, retry will be invoked in the
NetworkDispatcher thread. Clients may be relying on the ability to
perform blocking operations in retry(); a common example would be
clearing auth tokens in the event of an auth error, which may
require disk I/O.

In order to keep the same API contract when using AsyncRequestQueue,
rework NetworkUtility to permit BasicAsyncNetwork to invoke retry in
the blocking executor.