### PR TITLE
Add developers stanza to Volley POM.

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -42,6 +42,12 @@ publishing {
                     developerConnection = 'scm:git:ssh://git@github.com/google/volley.git'
                     url = 'https://github.com/google/volley'
                 }
+                developers {
+                    developer {
+                        name = 'The Volley Team'
+                        email = 'noreply+volley@google.com'
+                    }
+                }
             }
 
             // Release AAR, Sources, and JavaDoc


### PR DESCRIPTION
Based on the ZetaSketch project:
https://github.com/google/zetasketch/blob/93f3b8974acc1ef4cb470b91645f921436a830e7/build.gradle#L148
which is published to Maven Central.

See #394