### PR TITLE
Remove new constructors from JsonRequests which are breaking builds.

### DIFF
--- a/src/main/java/com/android/volley/toolbox/JsonArrayRequest.java
+++ b/src/main/java/com/android/volley/toolbox/JsonArrayRequest.java
@@ -25,11 +25,10 @@ import com.android.volley.Response.Listener;
 import java.io.UnsupportedEncodingException;
 import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * A request for retrieving a {@link JSONArray} response body at a given URL, allowing for an
- * optional {@link JSONObject} to be passed in as part of the request body.
+ * optional {@link JSONArray} to be passed in as part of the request body.
  */
 public class JsonArrayRequest extends JsonRequest<JSONArray> {
 
@@ -43,30 +42,6 @@ public class JsonArrayRequest extends JsonRequest<JSONArray> {
     public JsonArrayRequest(
             String url, Listener<JSONArray> listener, @Nullable ErrorListener errorListener) {
         super(Method.GET, url, null, listener, errorListener);
-    }
-
-    /**
-     * Creates a new request.
-     *
-     * @param method the HTTP method to use
-     * @param url URL to fetch the JSON from
-     * @param jsonRequest A {@link JSONObject} to post with the request. Null indicates no
-     *     parameters will be posted along with request.
-     * @param listener Listener to receive the JSON response
-     * @param errorListener Error listener, or null to ignore errors.
-     */
-    public JsonArrayRequest(
-            int method,
-            String url,
-            @Nullable JSONObject jsonRequest,
-            Listener<JSONArray> listener,
-            @Nullable ErrorListener errorListener) {
-        super(
-                method,
-                url,
-                jsonRequest != null ? jsonRequest.toString() : null,
-                listener,
-                errorListener);
     }
 
     /**

--- a/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
+++ b/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
@@ -23,7 +23,6 @@ import com.android.volley.Response;
 import com.android.volley.Response.ErrorListener;
 import com.android.volley.Response.Listener;
 import java.io.UnsupportedEncodingException;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -79,30 +78,6 @@ public class JsonObjectRequest extends JsonRequest<JSONObject> {
             int method,
             String url,
             @Nullable JSONObject jsonRequest,
-            Listener<JSONObject> listener,
-            @Nullable ErrorListener errorListener) {
-        super(
-                method,
-                url,
-                jsonRequest != null ? jsonRequest.toString() : null,
-                listener,
-                errorListener);
-    }
-
-    /**
-     * Creates a new request.
-     *
-     * @param method the HTTP method to use
-     * @param url URL to fetch the JSON from
-     * @param jsonRequest A {@link JSONArray} to post with the request. Null indicates no parameters
-     *     will be posted along with request.
-     * @param listener Listener to receive the JSON response
-     * @param errorListener Error listener, or null to ignore errors.
-     */
-    public JsonObjectRequest(
-            int method,
-            String url,
-            @Nullable JSONArray jsonRequest,
             Listener<JSONObject> listener,
             @Nullable ErrorListener errorListener) {
         super(


### PR DESCRIPTION
These conflict with pre-existing constructors - since the request argument is nullable, existing code which passes in null requests is no longer invoking an unambiguous constructor.

See #419 for more details and a workaround.

These constructors were added in #406 and have not yet been included in a public release, so they are safe to remove.