### PR TITLE
Fix listing of dependencies in Volley POM files.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,24 +5,17 @@ android {
 }
 
 dependencies {
-    implementation "androidx.annotation:annotation:1.0.1"
+    compileOnly "androidx.annotation:annotation:1.0.1"
 
     testImplementation project(":testing")
     testImplementation "junit:junit:4.12"
     testImplementation "org.hamcrest:hamcrest-library:1.3"
     testImplementation "org.mockito:mockito-core:2.19.0"
     testImplementation "org.robolectric:robolectric:3.4.2"
+    // TODO(#424): Fix this dependency at the library level.
+    testImplementation "androidx.annotation:annotation:1.0.1"
 }
 
-publishing {
-    publications {
-        library(MavenPublication) {
-            artifactId 'volley'
-            pom {
-                name = 'Volley'
-                description = 'An HTTP library that makes networking for Android apps easier and, most importantly, faster.'
-            }
-            artifact "$buildDir/outputs/aar/core-release.aar"
-        }
-    }
-}
+project.ext.artifactId = 'volley'
+project.ext.pomName = 'Volley'
+project.ext.pomDescription = 'An HTTP library that makes networking for Android apps easier and, most importantly, faster.'

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation project(":core")
-    implementation "androidx.annotation:annotation:1.0.1"
+    compileOnly "androidx.annotation:annotation:1.0.1"
     compileOnly "org.chromium.net:cronet-embedded:76.3809.111"
 
     testImplementation project(":testing")
@@ -8,17 +8,10 @@ dependencies {
     testImplementation "junit:junit:4.12"
     testImplementation "org.mockito:mockito-core:2.19.0"
     testImplementation "org.robolectric:robolectric:3.4.2"
+    // TODO(#424): Fix this dependency at the library level.
+    testImplementation "androidx.annotation:annotation:1.0.1"
 }
 
-publishing {
-    publications {
-        library(MavenPublication) {
-            artifactId 'volley-cronet'
-            pom {
-                name = 'Volley Cronet'
-                description = 'Cronet support for Volley.'
-            }
-            artifact "$buildDir/outputs/aar/cronet-release.aar"
-        }
-    }
-}
+project.ext.artifactId = 'volley-cronet'
+project.ext.pomName = 'Volley Cronet'
+project.ext.pomDescription = 'Cronet support for Volley.'

--- a/publish.gradle
+++ b/publish.gradle
@@ -26,46 +26,53 @@ artifacts {
     archives sourcesJar
 }
 
-publishing {
-    publications {
-        library(MavenPublication) {
-            groupId 'com.android.volley'
-            version project.version
-            pom {
-                name = 'Volley'
-                url = 'https://github.com/google/volley'
-                packaging 'aar'
-                licenses {
-                    license {
-                      name = "The Apache License, Version 2.0"
-                      url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/google/volley.git'
-                    developerConnection = 'scm:git:ssh://git@github.com/google/volley.git'
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // Depend on the release AAR
+                from project.components.release
+
+                groupId 'com.android.volley'
+                artifactId project.artifactId
+                version project.version
+                pom {
+                    name = project.pomName
+                    description = project.pomDescription
                     url = 'https://github.com/google/volley'
-                }
-                developers {
-                    developer {
-                        name = 'The Volley Team'
-                        email = 'noreply+volley@google.com'
+                    packaging 'aar'
+                    licenses {
+                        license {
+                            name = "The Apache License, Version 2.0"
+                            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git://github.com/google/volley.git'
+                        developerConnection = 'scm:git:ssh://git@github.com/google/volley.git'
+                        url = 'https://github.com/google/volley'
+                    }
+                    developers {
+                        developer {
+                            name = 'The Volley Team'
+                            email = 'noreply+volley@google.com'
+                        }
                     }
                 }
+
+                // Also include sources and JavaDoc
+                artifact sourcesJar
+                artifact javadocJar
             }
-
-            // Release AAR, Sources, and JavaDoc
-            artifact sourcesJar
-            artifact javadocJar
         }
-    }
 
-    repositories {
-        maven {
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
-            credentials {
-                username = System.env.OSSRH_DEPLOY_USERNAME
-                password = System.env.OSSRH_DEPLOY_PASSWORD
+        repositories {
+            maven {
+                url = "https://oss.sonatype.org/content/repositories/snapshots/"
+                credentials {
+                    username = System.env.OSSRH_DEPLOY_USERNAME
+                    password = System.env.OSSRH_DEPLOY_PASSWORD
+                }
             }
         }
     }


### PR DESCRIPTION
We were depending directly on the .aar, which loses the dependency information from the build configuration itself.

This caused android.annotations to (correctly) show up as a dependency. Since it is only needed for annotations (like `@Nullable`) that don't need to be retained at runtime, we can mark this as a compileOnly dependency, matching its former "provided" state, to prevent Volley users from needing it. However, this introduces a compiler warning in the tests, since `@RestrictTo` has RetentionPolicy.CLASS and is not present at compile time; since we apply -Werror to all compile tasks, this becomes a compiler error. For now, to keep the build as close as possible to the prior state, add the annotations as an implementation dependency to the tests; a proper fix is tracked in #424.

The only resulting change to the POM files is that volley-cronet declares a dependency on volley.

Note that volley-cronet doesn't declare a dependency on Cronet because there are two plausible choices for how to use Cronet - the version in GmsCore, or the standalone version. There's no great way to codify this dependency choice, so leave it unstated.

Fixes #402