### PR TITLE
Declare volley-cronet's dependency on volley as an "api" dependency.

### DIFF
--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation project(":core")
+    api project(":core")
     compileOnly "androidx.annotation:annotation:1.0.1"
     compileOnly "org.chromium.net:cronet-embedded:76.3809.111"
 


### PR DESCRIPTION
Matches recommendation at https://docs.gradle.org/current/userguide/java_library_plugin.html. The effect is that apps depending on volley-cronet don't also need to depend on volley. This makes sense, since CronetHttpStack's public API depends on multiple Volley classes and can't be used in isolation.