### PR TITLE
Fix nullability issue in sample code

### DIFF
--- a/docs/requestqueue.md
+++ b/docs/requestqueue.md
@@ -142,7 +142,7 @@ class MySingleton constructor(context: Context) {
         ImageLoader(requestQueue,
                 object : ImageLoader.ImageCache {
                     private val cache = LruCache<String, Bitmap>(20)
-                    override fun getBitmap(url: String): Bitmap {
+                    override fun getBitmap(url: String): Bitmap? {
                         return cache.get(url)
                     }
                     override fun putBitmap(url: String, bitmap: Bitmap) {


### PR DESCRIPTION
[ImageLoader.ImageCache.getBitmap](https://github.com/google/volley/blob/master/core/src/main/java/com/android/volley/toolbox/ImageLoader.java#L74) is `@Nullable`, so the Kotlin code should return `Bitmap?`, not `Bitmap`. Otherwise, the code may fail to compile or crash at runtime due to added safety checks, depending on compiler behavior.

See #445 