### PR TITLE
Only log debug messages when DEBUG is True

### DIFF
--- a/core/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
+++ b/core/src/main/java/com/android/volley/toolbox/BasicAsyncNetwork.java
@@ -16,7 +16,7 @@
 
 package com.android.volley.toolbox;
 
-import static com.android.volley.toolbox.NetworkUtility.logSlowRequests;
+import static com.android.volley.toolbox.NetworkUtility.logRequestSummary;
 
 import android.os.SystemClock;
 import androidx.annotation.NonNull;
@@ -213,9 +213,9 @@ public class BasicAsyncNetwork extends AsyncNetwork {
             OnRequestComplete callback,
             List<Header> responseHeaders,
             byte[] responseContents) {
-        // if the request is slow, log it.
+        // log request when debugging is enabled.
         long requestLifetime = SystemClock.elapsedRealtime() - requestStartMs;
-        logSlowRequests(requestLifetime, request, responseContents, statusCode);
+        logRequestSummary(requestLifetime, request, responseContents, statusCode);
 
         if (statusCode < 200 || statusCode > 299) {
             onRequestFailed(

--- a/core/src/main/java/com/android/volley/toolbox/BasicNetwork.java
+++ b/core/src/main/java/com/android/volley/toolbox/BasicNetwork.java
@@ -124,9 +124,9 @@ public class BasicNetwork implements Network {
                     responseContents = new byte[0];
                 }
 
-                // if the request is slow, log it.
+                // log request when debugging is enabled.
                 long requestLifetime = SystemClock.elapsedRealtime() - requestStart;
-                NetworkUtility.logSlowRequests(
+                NetworkUtility.logRequestSummary(
                         requestLifetime, request, responseContents, statusCode);
 
                 if (statusCode < 200 || statusCode > 299) {

--- a/core/src/main/java/com/android/volley/toolbox/NetworkUtility.java
+++ b/core/src/main/java/com/android/volley/toolbox/NetworkUtility.java
@@ -50,7 +50,7 @@ final class NetworkUtility {
     /** Logs requests that took over SLOW_REQUEST_THRESHOLD_MS to complete. */
     static void logSlowRequests(
             long requestLifetime, Request<?> request, byte[] responseContents, int statusCode) {
-        if (VolleyLog.DEBUG || requestLifetime > SLOW_REQUEST_THRESHOLD_MS) {
+        if (VolleyLog.DEBUG && requestLifetime > SLOW_REQUEST_THRESHOLD_MS) {
             VolleyLog.d(
                     "HTTP response for request=<%s> [lifetime=%d], [size=%s], "
                             + "[rc=%d], [retryCount=%s]",

--- a/core/src/main/java/com/android/volley/toolbox/NetworkUtility.java
+++ b/core/src/main/java/com/android/volley/toolbox/NetworkUtility.java
@@ -43,14 +43,12 @@ import java.util.List;
  * BasicAsyncNetwork}
  */
 final class NetworkUtility {
-    private static final int SLOW_REQUEST_THRESHOLD_MS = 3000;
-
     private NetworkUtility() {}
 
-    /** Logs requests that took over SLOW_REQUEST_THRESHOLD_MS to complete. */
-    static void logSlowRequests(
+    /** Logs a summary about the request when debug logging is enabled. */
+    static void logRequestSummary(
             long requestLifetime, Request<?> request, byte[] responseContents, int statusCode) {
-        if (VolleyLog.DEBUG && requestLifetime > SLOW_REQUEST_THRESHOLD_MS) {
+        if (VolleyLog.DEBUG) {
             VolleyLog.d(
                     "HTTP response for request=<%s> [lifetime=%d], [size=%s], "
                             + "[rc=%d], [retryCount=%s]",


### PR DESCRIPTION
According to the internal comments and other usage, this message should only be logged when DEBUG is True. The log entry can potentially contain sensitive data in the case where authentication tokens are part of a GET request and so it should be possible for the user of Volley to disable logging by setting DEBUG to False even in the case where the network request is "slow."

Fixes #452 