### PR TITLE
Fix: Solve 204 No Content Error

### DIFF
--- a/core/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
+++ b/core/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
@@ -93,7 +93,6 @@ public class JsonObjectRequest extends JsonRequest<JSONObject> {
     protected Response<JSONObject> parseNetworkResponse(NetworkResponse response) {
         Cache.Entry cacheHeaders = HttpHeaderParser.parseCacheHeaders(response);
         try {
-            //Check Empty Response
             if (response.data == null || response.data.length == 0) {
                 return Response.success(new JSONObject(), cacheHeaders);
             }

--- a/core/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
+++ b/core/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
@@ -93,6 +93,7 @@ public class JsonObjectRequest extends JsonRequest<JSONObject> {
     protected Response<JSONObject> parseNetworkResponse(NetworkResponse response) {
         Cache.Entry cacheHeaders = HttpHeaderParser.parseCacheHeaders(response);
         try {
+            //Check Empty Response
             if (response.data == null || response.data.length == 0) {
                 return Response.success(new JSONObject(), cacheHeaders);
             }

--- a/core/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
+++ b/core/src/main/java/com/android/volley/toolbox/JsonObjectRequest.java
@@ -17,6 +17,7 @@
 package com.android.volley.toolbox;
 
 import androidx.annotation.Nullable;
+import com.android.volley.Cache;
 import com.android.volley.NetworkResponse;
 import com.android.volley.ParseError;
 import com.android.volley.Response;
@@ -90,17 +91,18 @@ public class JsonObjectRequest extends JsonRequest<JSONObject> {
 
     @Override
     protected Response<JSONObject> parseNetworkResponse(NetworkResponse response) {
+        Cache.Entry cacheHeaders = HttpHeaderParser.parseCacheHeaders(response);
         try {
+            if (response.data == null || response.data.length == 0) {
+                return Response.success(new JSONObject(), cacheHeaders);
+            }
             String jsonString =
                     new String(
                             response.data,
                             HttpHeaderParser.parseCharset(response.headers, PROTOCOL_CHARSET));
-            return Response.success(
-                    new JSONObject(jsonString), HttpHeaderParser.parseCacheHeaders(response));
-        } catch (UnsupportedEncodingException e) {
+            return Response.success(new JSONObject(jsonString), cacheHeaders);
+        } catch (UnsupportedEncodingException | JSONException e) {
             return Response.error(new ParseError(e));
-        } catch (JSONException je) {
-            return Response.error(new ParseError(je));
         }
     }
 }


### PR DESCRIPTION
### Solve 204 No Content Error

_See issue_ #431 _for Context_

- Refactored parseNetworkResponse to handle 204 No Content responses gracefully. 
- Added check for null or empty response.data to return Response.success with an empty JSONObject instead of triggering a Response.error. 
- Optimized code by extracting HttpHeaderParser.parseCacheHeaders to a local variable for reuse, improving readability and performance. 
- Maintained existing functionality for non-empty responses while enhancing clarity and maintainability.



